### PR TITLE
security: harden OAuth flow and token handling

### DIFF
--- a/client/src/features/auth/auth.ts
+++ b/client/src/features/auth/auth.ts
@@ -16,10 +16,12 @@ export const isAuthenticated = (): boolean => getAccessToken() !== null;
 
 export const clearSession = () => clearTokens();
 
-// Le tokens da query string apos o callback OAuth, persiste e limpa a URL.
-// Deve rodar uma vez no bootstrap, antes da arvore React montar.
+// Le tokens do FRAGMENT (#) apos o callback OAuth, persiste e limpa a URL.
+// O backend devolve os tokens no fragment (nao na query) para nao vazar em
+// logs/Referer. Deve rodar uma vez no bootstrap, antes da arvore React montar.
 export const bootstrapAuthFromUrl = () => {
-  const params = new URLSearchParams(window.location.search);
+  const hash = window.location.hash.replace(/^#/, "");
+  const params = new URLSearchParams(hash);
   const accessToken = params.get("access_token");
   const refreshToken = params.get("refresh_token");
 
@@ -38,9 +40,13 @@ let inFlightRefresh: Promise<string | null> | null = null;
 
 const requestRefresh = async (refreshToken: string): Promise<string | null> => {
   try {
-    const response = await fetch(
-      getApiUrl(`/refresh_token?refresh_token=${encodeURIComponent(refreshToken)}`)
-    );
+    // POST com o refresh token no corpo (nao na query) para nao vazar em
+    // logs/URL/Referer. Espelha o endpoint POST /refresh_token do backend.
+    const response = await fetch(getApiUrl("/refresh_token"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
 
     if (!response.ok) {
       clearTokens();

--- a/server/app.js
+++ b/server/app.js
@@ -1,7 +1,22 @@
 import express from "express";
 import authRoutes from "./routes/auth";
+import { env } from "./config/env";
 
 const app = express();
+
+// CORS restrito ao cliente configurado (defesa em profundidade): so o
+// CLIENT_URL pode ler respostas da API. Tambem responde ao preflight.
+app.use((req, res, next) => {
+  res.header("Access-Control-Allow-Origin", env.clientUrl);
+  res.header("Vary", "Origin");
+  res.header("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+  res.header("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") return res.sendStatus(204);
+  return next();
+});
+
+app.use(express.json());
 
 app.get("/", (req, res) => {
   res.send("health check");

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -9,39 +9,76 @@ import {
 
 const router = Router();
 const stateKey = "spotify_auth_state";
+const isHttps = env.redirectUri.startsWith("https");
+
+// Le um cookie do header cru (sem depender de cookie-parser).
+const readCookie = (req, name) => {
+  const header = req.headers.cookie;
+  if (!header) return null;
+
+  for (const part of header.split(";")) {
+    const [key, ...rest] = part.trim().split("=");
+    if (key === name) return decodeURIComponent(rest.join("="));
+  }
+
+  return null;
+};
+
+// Redireciona ao cliente passando dados no FRAGMENT (#) em vez de query (?):
+// o fragment nao e enviado a servidores, nao entra em logs de acesso nem no
+// header Referer. Evita vazamento de access/refresh token.
+const redirectToClient = (res, params) => {
+  const base = env.clientUrl.replace(/\/+$/, "");
+  return res.redirect(`${base}/#${new URLSearchParams(params).toString()}`);
+};
 
 router.get("/login", (req, res) => {
   const state = generateRandomString(16);
 
-  res.cookie(stateKey, state);
+  res.cookie(stateKey, state, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: isHttps,
+    maxAge: 10 * 60 * 1000,
+  });
   res.redirect(getSpotifyAuthorizationUrl(state));
 });
 
 router.get("/callback", async (req, res) => {
   const code = req.query.code;
+  const state = req.query.state;
+  const storedState = readCookie(req, stateKey);
+
+  res.clearCookie(stateKey);
+
+  // Anti-CSRF: o state devolvido pelo Spotify precisa bater com o cookie
+  // setado no /login. Sem isso, a protecao de state do OAuth e inutil.
+  if (!state || !storedState || state !== storedState) {
+    return redirectToClient(res, { error: "state_mismatch" });
+  }
 
   if (!code) {
-    const queryParams = new URLSearchParams({ error: "missing_code" });
-    return res.redirect(`${env.clientUrl}?${queryParams.toString()}`);
+    return redirectToClient(res, { error: "missing_code" });
   }
 
   try {
-    const { access_token, refresh_token, expires_in } = await requestAccessToken(code);
-    const queryParams = new URLSearchParams({
+    const { access_token, refresh_token, expires_in } = await requestAccessToken(
+      code
+    );
+
+    return redirectToClient(res, {
       access_token,
       refresh_token,
       expires_in,
     });
-
-    return res.redirect(`${env.clientUrl}?${queryParams.toString()}`);
   } catch (error) {
-    const queryParams = new URLSearchParams({ error: "invalid_token" });
-    return res.redirect(`${env.clientUrl}?${queryParams.toString()}`);
+    return redirectToClient(res, { error: "invalid_token" });
   }
 });
 
-router.get("/refresh_token", async (req, res) => {
-  const refreshToken = req.query.refresh_token;
+// POST com o refresh token no corpo (nao na query) para nao vazar em logs/URL.
+router.post("/refresh_token", async (req, res) => {
+  const refreshToken = req.body?.refresh_token;
 
   if (!refreshToken) {
     return res.status(400).json({ error: "missing_refresh_token" });

--- a/server/utils/common.js
+++ b/server/utils/common.js
@@ -1,12 +1,8 @@
-//generetes random string containg numbers and letters
+import { randomBytes } from "crypto";
 
-export const generateRandomString = (length) => {
-  let text = "";
-  const possible =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-
-  for (let i = 0; i < length; i++)
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-
-  return text;
-};
+// Gera uma string aleatoria com seguranca criptografica (CSPRNG).
+// Usada como `state` anti-CSRF do fluxo OAuth — nao pode ser previsivel.
+export const generateRandomString = (length) =>
+  randomBytes(Math.ceil(length / 2))
+    .toString("hex")
+    .slice(0, length);


### PR DESCRIPTION
## Contexto

Varredura de segurança do fluxo de autenticação (OAuth 2.0 com a Web API do Spotify) antes de seguir com o projeto. Não há vazamento de segredos: `.env` está no `.gitignore`, nunca foi commitado, e o histórico não contém `CLIENT_ID`/`CLIENT_SECRET`. Os arquivos `.env.example` têm só placeholders. As correções abaixo endurecem o fluxo de tokens.

## Correções de segurança

- **Validação do `state` (anti-CSRF):** `/callback` agora compara o `state` devolvido pelo Spotify com um cookie `httpOnly` setado no `/login`. Antes o cookie era criado mas **nunca verificado**, tornando a proteção de CSRF do OAuth inútil.
- **CSPRNG no `state`:** gerado com `crypto.randomBytes` em vez de `Math.random()` (não-criptográfico e previsível).
- **Tokens fora da query string:** o backend passa `access_token`/`refresh_token` ao cliente via **fragment (`#`)** em vez de query (`?`). Fragment não é enviado a servidores, não entra em logs de acesso nem no header `Referer`. O cliente lê do fragment no bootstrap.
- **`/refresh_token` como POST:** o refresh token vai no **corpo** da requisição (cliente + servidor), não mais na URL/query. Cookie de `state` endurecido: `httpOnly`, `sameSite=lax`, `secure` quando HTTPS, com expiração.
- **CORS restrito:** respostas liberadas apenas para `CLIENT_URL` (antes sem CORS explícito), + parsing de JSON no corpo.

## Escopo / notas

- App é **read-only** (nenhuma escrita na conta do usuário); tokens vivem só no navegador durante a sessão.
- Alterações de `docs/` **não** entram neste PR (a pedido).
- Build do cliente (`tsc && vite build`) passa.

## Teste manual sugerido

1. Login com Spotify → token chega via `#`, some da URL após o bootstrap.
2. Adulterar o `state` no callback → redireciona com `error=state_mismatch`.
3. Expirar o access token → refresh via POST renova sem recarregar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)