### PR TITLE
fix(mobile): corrige card de usuario e navbar em telas estreitas

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -137,6 +137,8 @@
 /* ---------- Cabecalho ---------- */
 
 .app-header {
+  --nav-target: 2.15rem;
+
   position: sticky;
   top: 0;
   z-index: 40;
@@ -144,6 +146,28 @@
   background: color-mix(in srgb, var(--sand-1) 72%, transparent);
   backdrop-filter: blur(20px) saturate(140%);
   -webkit-backdrop-filter: blur(20px) saturate(140%);
+}
+
+/*
+ * Elevacao progressiva ao rolar, sem JS: a animacao e conduzida pelo scroll da
+ * pagina. Onde `animation-timeline` nao existe (Firefox, Safari antigo) o header
+ * simplesmente fica como esta — nada quebra.
+ */
+@supports (animation-timeline: scroll()) {
+  @media (prefers-reduced-motion: no-preference) {
+    .app-header {
+      animation: header-elevate linear both;
+      animation-timeline: scroll(root block);
+      animation-range: 0 5rem;
+    }
+  }
+}
+
+@keyframes header-elevate {
+  to {
+    background: color-mix(in srgb, var(--sand-1) 90%, transparent);
+    box-shadow: 0 12px 30px -26px var(--sand-a12);
+  }
 }
 
 .app-header-row {
@@ -198,7 +222,7 @@ a:hover > .brand-mark {
   align-items: center;
   justify-content: center;
   gap: 0.42rem;
-  min-height: 2.1rem;
+  min-height: var(--nav-target);
   padding: 0 0.85rem;
   border-radius: 999px;
   color: var(--gray-11);
@@ -226,6 +250,26 @@ a:hover > .brand-mark {
     0 8px 20px -18px var(--accent-a9);
 }
 
+/*
+ * Feedback de toque. O `-webkit-tap-highlight-color: transparent` global remove
+ * o realce nativo do mobile, entao sem isto o header nao responde visualmente a
+ * nenhum toque — so a estados de hover, que no celular nao existem.
+ */
+.app-header :is(.nav-action, .brand-mark, .rt-IconButton, .rt-Button):active {
+  transform: scale(0.94);
+}
+
+.app-header :is(.rt-IconButton, .rt-Button) {
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    transform 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.nav-action:active {
+  transform: scale(0.96);
+}
+
 .utility-actions {
   justify-self: end;
   flex: 0 0 auto;
@@ -240,23 +284,28 @@ a:hover > .brand-mark {
   box-shadow: none;
 }
 
+/*
+ * Um tamanho so para todos os alvos do header (`--nav-target`), porque no mobile
+ * eles precisam crescer juntos: no toque, 2.15rem colados eram alvo pequeno e
+ * dificil de acertar.
+ */
 .utility-actions .utility-icon-action {
-  width: 2.15rem;
-  min-width: 2.15rem;
-  height: 2.15rem;
+  width: var(--nav-target);
+  min-width: var(--nav-target);
+  height: var(--nav-target);
 }
 
 .logout-action {
-  min-height: 2.15rem;
+  min-height: var(--nav-target);
   padding-inline: 0.72rem;
   gap: 0.38rem;
 }
 
 .player-nav-slot {
   display: inline-flex;
-  width: 2.15rem;
-  height: 2.15rem;
-  flex: 0 0 2.15rem;
+  width: var(--nav-target);
+  height: var(--nav-target);
+  flex: 0 0 var(--nav-target);
   align-items: center;
   justify-content: center;
 }
@@ -305,8 +354,18 @@ a:hover > .brand-mark {
 }
 
 @media (max-width: 640px) {
+  /*
+   * No toque os alvos crescem (~38px) e o header encolhe: sem hover, o que vale
+   * e acertar o botao com o dedo, e o cabecalho e sticky — cada pixel dele fica
+   * ocupando a tela o tempo todo.
+   */
+  .app-header {
+    --nav-target: 2.4rem;
+  }
+
   .app-header-row {
-    row-gap: var(--space-2);
+    row-gap: var(--space-1);
+    padding-block: var(--space-2);
   }
 
   .brand-mark {
@@ -316,6 +375,7 @@ a:hover > .brand-mark {
 
   .nav-actions {
     gap: 0;
+    padding: 0.15rem;
     justify-content: space-between;
   }
 
@@ -327,12 +387,12 @@ a:hover > .brand-mark {
 
   .utility-actions {
     flex: 0 0 auto;
-    gap: 0.35rem;
+    gap: 0.3rem;
   }
 
   .logout-action {
-    width: 2.15rem;
-    min-width: 2.15rem;
+    width: var(--nav-target);
+    min-width: var(--nav-target);
     padding: 0;
   }
 }
@@ -682,13 +742,16 @@ a:hover > .brand-mark {
   }
 }
 
+/*
+ * Base = card empilhado (mobile). Aqui a faixa NAO pode ter `flex-basis`: o eixo
+ * principal do `.profile-layout` e vertical, entao um basis viraria altura fixa
+ * e a caixa ficaria alta e vazia, com os numeros boiando no meio.
+ */
 .stat-strip {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  flex: 0 1 20rem;
-  align-self: center;
+  width: 100%;
   min-width: 0;
-  max-width: 21rem;
   overflow: hidden;
   border: 1px solid var(--sand-a5);
   border-radius: var(--radius-3);
@@ -720,7 +783,23 @@ a:hover > .brand-mark {
   letter-spacing: -0.03em;
 }
 
-@media (max-width: 640px) {
+/*
+ * A partir daqui o card vira linha. 768px e o breakpoint `sm` do Radix, usado no
+ * `direction={{ initial: "column", sm: "row" }}` do Profile — os dois precisam
+ * bater, senao existe uma faixa de larguras com o layout empilhado e o CSS de
+ * desktop valendo ao mesmo tempo.
+ */
+@media (min-width: 768px) {
+  .stat-strip {
+    flex: 0 1 20rem;
+    align-self: center;
+    width: auto;
+    max-width: 21rem;
+  }
+}
+
+/* Card empilhado: tudo que so faz sentido antes do layout virar linha. */
+@media (max-width: 767px) {
   .profile-card {
     padding: var(--space-4);
   }
@@ -738,17 +817,12 @@ a:hover > .brand-mark {
     align-items: flex-start;
   }
 
-  .stat-strip {
-    width: 100%;
-    min-width: 0;
-  }
-
   .stat-cell {
-    padding: var(--space-2);
+    padding: var(--space-3) var(--space-2);
   }
 
   .stat-cell .stat-value {
-    font-size: clamp(0.8rem, 3.6vw, 1rem);
+    font-size: clamp(0.9rem, 3.6vw, 1.05rem);
   }
 }
 


### PR DESCRIPTION
Duas correcoes de responsividade, so em `client/src/index.css`. Sem mudanca no
desktop e sem overflow horizontal em nenhuma largura testada.

## Card de usuario

`.stat-strip` usava `flex: 0 1 20rem`. O `flex-basis` vale **no eixo principal do
container**: no desktop o card e `row` e 20rem e largura (correto), mas no mobile
o layout vira `column` e os mesmos 20rem viram **altura**. Resultado: uma caixa
alta e vazia, com os numeros boiando no meio e divisorias gigantes. A media query
existente sobrescrevia so `width`/`min-width`, nunca o `flex`.

Havia um segundo problema no mesmo ponto: o `Profile` troca para linha no
breakpoint `sm` do Radix, que e **768px**, mas o CSS cortava em **640px**. Entre
640 e 768 o card ja estava empilhado com as regras de desktop valendo — o pior
caso de todos.

Agora a base do `.stat-strip` e a do card empilhado (sem `flex-basis`, largura
total) e as regras de linha vivem num `@media (min-width: 768px)`. Como
`.stat-strip` tambem e usado no `ProfileSkeleton`, o placeholder herda a correcao.

| faixa de stats | antes | depois |
| --- | --- | --- |
| 320px | 254x**320** (`basis: 320px`) | 254x**60** (`basis: auto`) |
| 700px | 230x**320** | 634x**63** |
| 1200px | 320x62 | 320x62 (igual) |

## Navbar

- **Alvos de toque**: os cinco utilitarios somavam `194x34`, encostados. Um token
  `--nav-target` passa a definir o tamanho de todos os alvos do header — 2.4rem
  no mobile, 2.15rem no desktop — em vez de cada regra ter o proprio valor fixo.
- **Altura**: o cabecalho sticky ocupava 110px em 320px de largura. Agora 104px,
  ja com os alvos maiores.
- **Feedback de toque**: o reset global usa
  `-webkit-tap-highlight-color: transparent`, entao no celular nao havia resposta
  visual nenhuma ao toque (todo o estado era `:hover`). Adicionado `:active` com
  escala curta nos alvos do header.
- **Elevacao ao rolar**, sem JS: `animation-timeline: scroll(root block)` da
  sombra ao header nos primeiros 5rem de rolagem, dentro de `@supports` e de
  `prefers-reduced-motion: no-preference`. Onde nao ha suporte, nada muda.

| navbar (320px) | antes | depois |
| --- | --- | --- |
| altura do header | 110px | 104px |
| faixa de utilitarios | 194x34 | 211x38 |
| item de navegacao | ~90x33 | 94x38 |

## Verificacao

`tsc && vite build` passam. Capturas com **viewport real via CDP**
(`Emulation.setDeviceMetricsOverride`) em 320/360/420/700/1200 — o `--window-size`
do Chrome headless tem largura minima de 500px e falseia teste de mobile, o que
mascarou o problema nas primeiras medicoes. O estado `:active` foi capturado
segurando o toque com `Input.dispatchMouseEvent`, e a elevacao conferida rolando
300px e lendo o `box-shadow` computado.

Independente do #6: nao ha sobreposicao entre os dois diffs.
