### PR TITLE
feat(mobile): redesenho mobile-first da navegacao, perfil e player (cloudflare)

### DIFF
--- a/client/src/components/Layout/AppShell.tsx
+++ b/client/src/components/Layout/AppShell.tsx
@@ -10,6 +10,7 @@ import React, { useState } from "react";
 import { AccentPicker } from "./AccentPicker";
 import { EqualizerMark } from "./EqualizerMark";
 import { GitHubNavButton } from "./GitHubNavButton";
+import { MobileTabBar } from "./MobileTabBar";
 import { ThemeToggle } from "./ThemeToggle";
 import { useAuth } from "../../features/auth/useAuth";
 import { PlayerDock, PlayerNavControl, useNowPlaying } from "../Player/MiniPlayer";
@@ -39,7 +40,7 @@ export const AppShell = ({ children, onLogout }: AppShellProps) => {
                 <Flex className="brand-mark" align="center" justify="center">
                   <EqualizerMark />
                 </Flex>
-                <Box display={{ initial: "none", xs: "block" }}>
+                <Box className="brand-copy">
                   <Text as="p" size="2" className="brand-title">
                     SpotfySplit
                   </Text>
@@ -114,6 +115,7 @@ export const AppShell = ({ children, onLogout }: AppShellProps) => {
         {children}
       </Container>
       <PlayerDock state={playerState} onDismiss={() => setIsPlayerDockHidden(true)} />
+      <MobileTabBar onLogout={handleLogout} />
     </Box>
   );
 };

--- a/client/src/components/Layout/AppShell.tsx
+++ b/client/src/components/Layout/AppShell.tsx
@@ -6,7 +6,7 @@ import {
 } from "@radix-ui/react-icons";
 import { Box, Button, Container, Flex, Text } from "@radix-ui/themes";
 import { Link, NavLink } from "react-router-dom";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AccentPicker } from "./AccentPicker";
 import { EqualizerMark } from "./EqualizerMark";
 import { GitHubNavButton } from "./GitHubNavButton";
@@ -26,6 +26,17 @@ export const AppShell = ({ children, onLogout }: AppShellProps) => {
   const playerState = useNowPlaying();
   const showPlayerDock = playerState.isPlaying && !isPlayerDockHidden;
   const handleLogout = onLogout ?? logout;
+
+  /*
+   * A dispensa vale ate a reproducao parar, nao ate a proxima faixa. Trocar de
+   * musica nao e intencao do usuario — a fila anda sozinha —, entao reabrir o
+   * dock a cada faixa viraria uma interrupcao a cada tres minutos, bem em cima
+   * da barra de navegacao. Voltar a tocar depois de parado, sim, e intencao: ai
+   * o player volta. Enquanto isso o icone do header e o caminho de volta.
+   */
+  useEffect(() => {
+    if (playerState.isPlaying) setIsPlayerDockHidden(false);
+  }, [playerState.isPlaying]);
 
   return (
     <Box
@@ -114,7 +125,9 @@ export const AppShell = ({ children, onLogout }: AppShellProps) => {
       <Container size="4" px={{ initial: "4", sm: "5" }} py={{ initial: "5", sm: "6" }}>
         {children}
       </Container>
-      <PlayerDock state={playerState} onDismiss={() => setIsPlayerDockHidden(true)} />
+      {showPlayerDock && (
+        <PlayerDock state={playerState} onDismiss={() => setIsPlayerDockHidden(true)} />
+      )}
       <MobileTabBar onLogout={handleLogout} />
     </Box>
   );

--- a/client/src/components/Layout/GitHubNavButton.tsx
+++ b/client/src/components/Layout/GitHubNavButton.tsx
@@ -1,7 +1,7 @@
 import { GitHubLogoIcon } from "@radix-ui/react-icons";
 import { IconButton, Tooltip } from "@radix-ui/themes";
 
-const GITHUB_URL = "https://github.com/RosaErick/spotifysplit";
+export const GITHUB_URL = "https://github.com/RosaErick/spotifysplit";
 
 export const GitHubNavButton = () => (
   <Tooltip content="GitHub do projeto">

--- a/client/src/components/Layout/MobileMoreMenu.tsx
+++ b/client/src/components/Layout/MobileMoreMenu.tsx
@@ -1,0 +1,137 @@
+import {
+  CheckIcon,
+  DotsHorizontalIcon,
+  ExitIcon,
+  GitHubLogoIcon,
+  InfoCircledIcon,
+  MoonIcon,
+  SunIcon,
+} from "@radix-ui/react-icons";
+import { Popover, Text } from "@radix-ui/themes";
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { ACCENT_OPTIONS, useAppTheme } from "./AppThemeProvider";
+import { GITHUB_URL } from "./GitHubNavButton";
+
+const THEME_OPTIONS = [
+  { value: "light", label: "Claro", Icon: SunIcon },
+  { value: "dark", label: "Escuro", Icon: MoonIcon },
+] as const;
+
+// Acoes de baixa frequencia da barra inferior: aparencia, links e sair.
+//
+// O seletor de acento aparece inline aqui, e nao como o Popover do
+// `AccentPicker`: no mobile, abrir um popover dentro de outro custa um toque a
+// mais e o clique-fora fecha os dois.
+export const MobileMoreMenu = ({ onLogout }: { onLogout: () => void }) => {
+  const { theme, toggleTheme, accent, setAccent } = useAppTheme();
+  const [open, setOpen] = useState(false);
+
+  const close = () => setOpen(false);
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger>
+        <button
+          type="button"
+          className="mobile-tab mobile-tab-more"
+          aria-label="Mais opções"
+        >
+          <span className="mobile-tab-mark" aria-hidden="true" />
+          <DotsHorizontalIcon className="mobile-tab-icon" />
+          <span className="mobile-tab-label">Mais</span>
+        </button>
+      </Popover.Trigger>
+
+      <Popover.Content
+        side="top"
+        align="end"
+        sideOffset={10}
+        className="mobile-more-panel"
+      >
+        <Text as="p" size="1" color="gray" weight="bold" className="section-eyebrow">
+          Aparência
+        </Text>
+
+        <div className="mobile-more-segment" role="group" aria-label="Tema">
+          {THEME_OPTIONS.map(({ value, label, Icon }) => {
+            const isActive = value === theme;
+
+            return (
+              <button
+                key={value}
+                type="button"
+                className={`mobile-more-segment-option ${
+                  isActive ? "mobile-more-segment-option-active" : ""
+                }`}
+                aria-pressed={isActive}
+                onClick={() => {
+                  if (!isActive) toggleTheme();
+                }}
+              >
+                <Icon />
+                <span>{label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mobile-more-accents" role="group" aria-label="Cor do tema">
+          {ACCENT_OPTIONS.map((option) => {
+            const isActive = option.value === accent;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                className={`mobile-more-accent ${
+                  isActive ? "mobile-more-accent-active" : ""
+                }`}
+                aria-pressed={isActive}
+                aria-label={option.label}
+                onClick={() => setAccent(option.value)}
+              >
+                <span
+                  className="mobile-more-accent-swatch"
+                  style={{ background: option.swatch }}
+                  aria-hidden="true"
+                />
+                {isActive && <CheckIcon className="mobile-more-accent-check" />}
+              </button>
+            );
+          })}
+        </div>
+
+        <hr className="mobile-more-divider" />
+
+        <Link to="/sobre" className="mobile-more-item" onClick={close}>
+          <InfoCircledIcon />
+          <span>Sobre o projeto</span>
+        </Link>
+
+        <a
+          href={GITHUB_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="mobile-more-item"
+          onClick={close}
+        >
+          <GitHubLogoIcon />
+          <span>GitHub</span>
+        </a>
+
+        <button
+          type="button"
+          className="mobile-more-item mobile-more-item-danger"
+          onClick={() => {
+            close();
+            onLogout();
+          }}
+        >
+          <ExitIcon />
+          <span>Sair</span>
+        </button>
+      </Popover.Content>
+    </Popover.Root>
+  );
+};

--- a/client/src/components/Layout/MobileTabBar.tsx
+++ b/client/src/components/Layout/MobileTabBar.tsx
@@ -1,0 +1,41 @@
+import {
+  BackpackIcon,
+  HomeIcon,
+  MagnifyingGlassIcon,
+} from "@radix-ui/react-icons";
+import { NavLink } from "react-router-dom";
+import { MobileMoreMenu } from "./MobileMoreMenu";
+
+// `end` so na home: sem isso a rota "/" casaria com qualquer caminho e a aba
+// ficaria sempre ativa.
+const TABS = [
+  { to: "/", label: "Início", Icon: HomeIcon, end: true },
+  { to: "/search", label: "Busca", Icon: MagnifyingGlassIcon, end: false },
+  { to: "/library", label: "Biblioteca", Icon: BackpackIcon, end: false },
+];
+
+// Navegacao principal do mobile, ancorada embaixo: e onde o polegar alcanca sem
+// reposicionar o aparelho. O cabecalho no topo fica so com marca e player.
+// Escondida por CSS a partir de 820px, onde o header volta a dar conta.
+export const MobileTabBar = ({ onLogout }: { onLogout: () => void }) => (
+  <nav className="mobile-tabbar" aria-label="Navegação principal">
+    <div className="mobile-tabbar-inner">
+      {TABS.map(({ to, label, Icon, end }) => (
+        <NavLink
+          key={to}
+          to={to}
+          end={end}
+          className={({ isActive }) =>
+            `mobile-tab ${isActive ? "mobile-tab-active" : ""}`
+          }
+        >
+          <span className="mobile-tab-mark" aria-hidden="true" />
+          <Icon className="mobile-tab-icon" />
+          <span className="mobile-tab-label">{label}</span>
+        </NavLink>
+      ))}
+
+      <MobileMoreMenu onLogout={onLogout} />
+    </div>
+  </nav>
+);

--- a/client/src/components/Layout/Skeleton.tsx
+++ b/client/src/components/Layout/Skeleton.tsx
@@ -42,40 +42,38 @@ export const CardGridSkeleton = ({
   </Grid>
 );
 
+// Espelha o layout do card de perfil: identidade, faixa de numeros e acao.
 export const ProfileSkeleton = () => (
   <Card className="hero-panel profile-card" mb="2">
-    <Flex
-      className="profile-layout"
-      align="center"
-      gap={{ initial: "4", sm: "6" }}
-      direction={{ initial: "column", sm: "row" }}
-    >
-      <Flex className="profile-identity" align="center" gap="4">
+    <Box className="profile-layout">
+      <Box className="profile-identity">
         <Box className="avatar-ring">
-          <Skeleton width="80px" height="80px" radius="999px" />
+          <Skeleton width="64px" height="64px" radius="999px" />
         </Box>
 
-        <Flex direction="column" gap="2" style={{ minWidth: 0, flex: "1 1 auto" }}>
-          <Skeleton width="8rem" height="0.55rem" />
-          <Skeleton width="min(18rem, 70vw)" height="1.65rem" />
-          <Flex align="center" gap="3" wrap="wrap">
-            <Skeleton width="4.4rem" height="1.25rem" radius="999px" />
-            <Skeleton width="7rem" height="1.75rem" radius="999px" />
-          </Flex>
-        </Flex>
-      </Flex>
+        <Box className="profile-heading" style={{ flex: "1 1 auto" }}>
+          <Skeleton width="min(15rem, 62%)" height="1.65rem" />
+          <Box mt="2">
+            <Skeleton width="7rem" height="0.6rem" />
+          </Box>
+        </Box>
+      </Box>
 
       <Box className="stat-strip">
         {Array.from({ length: 3 }).map((_, index) => (
           <Box className="stat-cell" key={index}>
-            <Skeleton width="56%" height="1rem" />
-            <Box mt="1">
-              <Skeleton width="72%" height="0.58rem" />
+            <Skeleton width="60%" height="1.2rem" />
+            <Box mt="2">
+              <Skeleton width="78%" height="0.58rem" />
             </Box>
           </Box>
         ))}
       </Box>
-    </Flex>
+
+      <Box className="profile-action">
+        <Skeleton height="2.75rem" />
+      </Box>
+    </Box>
   </Card>
 );
 

--- a/client/src/components/Player/MiniPlayer.tsx
+++ b/client/src/components/Player/MiniPlayer.tsx
@@ -40,6 +40,14 @@ const playableSubtitle = (item: PlayableItem) =>
     ? item.artists?.map((artist) => artist.name).join(", ")
     : item.show?.name;
 
+// A barra e um retrato do ultimo polling (30s), nao um cronometro: por isso ela
+// e decorativa e o tempo continua escrito ao lado do artista.
+const progressPercent = (durationMs?: number, progressMs?: number | null) => {
+  if (!durationMs || !progressMs) return null;
+
+  return Math.min(100, Math.max(0, (progressMs / durationMs) * 100));
+};
+
 export const useNowPlaying = (): NowPlayingState => {
   const playbackQuery = usePlaybackState();
   const queueQuery = useQueue();
@@ -130,24 +138,48 @@ type PlayerDockProps = {
   onDismiss: () => void;
 };
 
+/*
+ * No mobile o alvo primario e a faixa inteira, que abre no Spotify: o dedo mira
+ * a barra, nao um botao "Abrir" de 24px (que some abaixo de 640px). Sobram dois
+ * utilitarios, ambos com alvo de 44px, e o dispensar fica isolado por um filete
+ * — facil de acertar de proposito, dificil por acidente.
+ */
 export const PlayerDock = ({ state, onDismiss }: PlayerDockProps) => {
   if (!state.isPlaying || !state.item) return null;
+
+  const item = state.item;
+  const spotifyUrl = item.external_urls?.spotify;
+  const progress = progressPercent(item.duration_ms, state.progressMs);
 
   return (
     <Box className="player-dock" role="region" aria-label="Tocando agora">
       <Card className="player-dock-card">
-        <Flex align="center" justify="between" gap="4" wrap="wrap">
-          <PlayerSummary state={state} />
+        <Box className="player-dock-row">
+          {spotifyUrl ? (
+            <a
+              className="player-dock-link"
+              href={spotifyUrl}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`Abrir ${item.name} no Spotify`}
+            >
+              <PlayerSummary state={state} />
+            </a>
+          ) : (
+            <Box className="player-dock-link is-static">
+              <PlayerSummary state={state} />
+            </Box>
+          )}
 
-          <Flex align="center" gap="2" wrap="wrap" justify="end">
+          <Flex className="player-dock-actions" align="center" gap="2" justify="end">
             {state.nextItem && (
               <Text size="1" color="gray" className="mini-player-next">
                 Próxima: {state.nextItem.name}
               </Text>
             )}
-            {state.item.external_urls?.spotify && (
-              <Button asChild size="1" variant="soft">
-                <a href={state.item.external_urls.spotify} target="_blank" rel="noreferrer">
+            {spotifyUrl && (
+              <Button asChild size="1" variant="soft" className="player-dock-open">
+                <a href={spotifyUrl} target="_blank" rel="noreferrer">
                   <OpenInNewWindowIcon />
                   Abrir
                 </a>
@@ -155,8 +187,9 @@ export const PlayerDock = ({ state, onDismiss }: PlayerDockProps) => {
             )}
             <IconButton
               size="1"
-              variant="soft"
+              variant="ghost"
               color="gray"
+              className="player-dock-action clickable-control"
               aria-label="Atualizar player"
               onClick={state.refetch}
             >
@@ -166,13 +199,20 @@ export const PlayerDock = ({ state, onDismiss }: PlayerDockProps) => {
               size="1"
               variant="ghost"
               color="gray"
+              className="player-dock-action player-dock-dismiss clickable-control"
               aria-label="Recolher player"
               onClick={onDismiss}
             >
               <Cross2Icon />
             </IconButton>
           </Flex>
-        </Flex>
+        </Box>
+
+        {progress !== null && (
+          <Box className="player-dock-progress" aria-hidden="true">
+            <Box className="player-dock-progress-fill" style={{ width: `${progress}%` }} />
+          </Box>
+        )}
       </Card>
     </Box>
   );
@@ -265,6 +305,9 @@ const PlayerSummary = ({
 
   const imageUrl = playableImageUrl(state.item);
   const subtitle = playableSubtitle(state.item);
+  const durationMs = state.item.duration_ms;
+  const elapsed = state.progressMs ? formatDuration(state.progressMs) : "";
+  const timing = elapsed && durationMs ? `${elapsed} / ${formatDuration(durationMs)}` : elapsed;
 
   return (
     <Flex align="center" gap="3" minWidth="0">
@@ -286,7 +329,7 @@ const PlayerSummary = ({
         </Text>
         <Text as="p" size="1" color="gray" className="truncate-2">
           {subtitle || "Spotify"}
-          {state.progressMs ? ` · ${formatDuration(state.progressMs)}` : ""}
+          {timing ? ` · ${timing}` : ""}
         </Text>
       </Box>
     </Flex>

--- a/client/src/components/Profile/Profile.tsx
+++ b/client/src/components/Profile/Profile.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Badge, Box, Card, Flex, Heading, Text } from "@radix-ui/themes";
+import { Avatar, Box, Card, Heading, Text } from "@radix-ui/themes";
 import { useProfileOverview } from "../../shared/api/queries";
 import { formatNumber } from "../../utils/format";
 import { ImageStudioDialog } from "../../features/imageStudio";
@@ -14,6 +14,12 @@ const initialsOf = (name?: string) =>
     .slice(0, 2)
     .join("")
     .toUpperCase() || "SS";
+
+// O plano e a unica informacao propria do usuario nessa linha; o resto era
+// texto de reforco. Juntar tudo num rotulo so libera a linha que o badge
+// ocupava, que na coluna estreita valia mais para a acao do card.
+const connectionLabel = (product?: string) =>
+  product ? `Spotify · ${product}` : "Spotify";
 
 export const Profile = () => {
   const { data, isLoading, isError, error, refetch } = useProfileOverview();
@@ -32,13 +38,9 @@ export const Profile = () => {
   return (
     <Reveal>
       <Card className="hero-panel profile-card" mb="2">
-        <Flex
-          className="profile-layout"
-          align="center"
-          gap={{ initial: "4", sm: "6" }}
-          direction={{ initial: "column", sm: "row" }}
-        >
-          <Flex className="profile-identity" align="center" gap="4">
+        {/* Quem e voce -> seus numeros -> o que da para fazer. */}
+        <Box className="profile-layout">
+          <Box className="profile-identity">
             <Box className="avatar-ring">
               <Avatar
                 src={imageUrl}
@@ -48,35 +50,33 @@ export const Profile = () => {
               />
             </Box>
 
-            <Box style={{ minWidth: 0 }}>
-              <Text as="p" color="gray" className="section-eyebrow profile-eyebrow" mb="1">
-                Conectado ao Spotify
-              </Text>
-              <Heading className="display-heading truncate-2 profile-name" size={{ initial: "5", sm: "6" }}>
+            <Box className="profile-heading">
+              <Heading className="display-heading truncate-2 profile-name" size="6">
                 {profile.display_name}
               </Heading>
-              <Flex mt="2" align="center" gap="3" wrap="wrap">
-                <Badge variant="soft" radius="full" size="1">
-                  {profile.product || "spotify"}
-                </Badge>
-                <ImageStudioDialog />
-              </Flex>
+              <Text as="p" className="profile-meta">
+                {connectionLabel(profile.product)}
+              </Text>
             </Box>
-          </Flex>
+          </Box>
 
           <Box className="stat-strip">
             {stats.map(([label, value]) => (
               <Box className="stat-cell" key={label}>
-                <Heading className="display-heading stat-value" size={{ initial: "2", sm: "3" }}>
+                <Heading className="display-heading stat-value" size="3">
                   {value}
                 </Heading>
-                <Text as="p" size="1" color="gray" mt="1">
+                <Text as="p" size="1" color="gray" className="stat-label">
                   {label}
                 </Text>
               </Box>
             ))}
           </Box>
-        </Flex>
+
+          <Box className="profile-action">
+            <ImageStudioDialog />
+          </Box>
+        </Box>
       </Card>
     </Reveal>
   );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1575,7 +1575,7 @@ a:hover > .brand-mark {
 
   /* Com o player aberto, ele empilha acima da barra. */
   .has-player-dock {
-    padding-bottom: calc(10rem + env(safe-area-inset-bottom));
+    padding-bottom: calc(10.75rem + env(safe-area-inset-bottom));
   }
 
   .player-dock {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -327,73 +327,290 @@ a:hover > .brand-mark {
   background: var(--gray-a3) !important;
 }
 
+.brand-copy {
+  min-width: 0;
+}
+
+.brand-copy > * {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/*
+ * Abaixo de 820px o cabecalho para de tentar ser a versao web comprimida: a
+ * navegacao principal desce para a barra inferior (`.mobile-tabbar`), no alcance
+ * do polegar, e as acoes de baixa frequencia vao para o menu "Mais".
+ *
+ * Sobra um header de uma linha so com marca e player — o que liberou espaco para
+ * o nome do app voltar a aparecer no mobile.
+ */
 @media (max-width: 820px) {
   .app-header-row {
     grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-areas:
-      "brand tools"
-      "nav nav";
     column-gap: var(--space-3);
-    row-gap: var(--space-3);
-  }
-
-  .brand-link {
-    grid-area: brand;
+    padding-block: var(--space-2);
   }
 
   .nav-actions {
-    grid-area: nav;
-    width: 100%;
-    justify-self: stretch;
+    display: none;
   }
 
-  .utility-actions {
-    grid-area: tools;
-    justify-self: end;
+  /* O player fica: e contextual e muda sozinho. O resto e configuracao. */
+  .utility-actions > *:not(.player-nav-slot) {
+    display: none;
   }
 }
 
 @media (max-width: 640px) {
-  /*
-   * No toque os alvos crescem (~38px) e o header encolhe: sem hover, o que vale
-   * e acertar o botao com o dedo, e o cabecalho e sticky — cada pixel dele fica
-   * ocupando a tela o tempo todo.
-   */
   .app-header {
     --nav-target: 2.4rem;
-  }
-
-  .app-header-row {
-    row-gap: var(--space-1);
-    padding-block: var(--space-2);
   }
 
   .brand-mark {
     width: 2.25rem;
     height: 2.25rem;
   }
+}
 
-  .nav-actions {
-    gap: 0;
-    padding: 0.15rem;
-    justify-content: space-between;
-  }
+/* ---------- Navegacao inferior (mobile) ---------- */
 
-  .nav-action {
-    flex: 1 1 0;
-    min-width: 0;
-    padding: 0 0.4rem;
-  }
+/*
+ * Some no desktop, onde o header em uma linha ja resolve. Nao e o header
+ * reposicionado: e a navegacao primaria tratada como primaria, com alvos
+ * grandes e no terco inferior da tela.
+ */
+.mobile-tabbar {
+  display: none;
+}
 
-  .utility-actions {
-    flex: 0 0 auto;
-    gap: 0.3rem;
-  }
+.mobile-tabbar-inner {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.15rem;
+  padding: 0.25rem;
+  border: 1px solid var(--sand-a5);
+  border-radius: 1.2rem;
+  background:
+    linear-gradient(120deg, var(--accent-a2), transparent 55%),
+    color-mix(in srgb, var(--color-panel-solid) 90%, transparent);
+  box-shadow:
+    0 20px 50px -30px var(--sand-a12),
+    inset 0 1px 0 color-mix(in srgb, #fff 22%, transparent);
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+}
 
-  .logout-action {
-    width: var(--nav-target);
-    min-width: var(--nav-target);
-    padding: 0;
+.mobile-tab {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  min-height: 2.9rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.18rem;
+  padding: 0.32rem 0.25rem 0.26rem;
+  border: 0;
+  border-radius: 0.95rem;
+  background: transparent;
+  color: var(--gray-11);
+  font: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    color 180ms ease,
+    background 180ms ease,
+    transform 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/*
+ * Marca de indice sobre a aba ativa — eco da numeracao de tracklist do conceito
+ * "Liner Notes". Cresce a partir do centro em vez de aparecer seca.
+ */
+.mobile-tab-mark {
+  position: absolute;
+  top: 0.24rem;
+  width: 1.05rem;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--accent-9);
+  opacity: 0;
+  transform: scaleX(0.2);
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 200ms ease;
+}
+
+.mobile-tab-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.mobile-tab-label {
+  max-width: 100%;
+  overflow: hidden;
+  font-size: 0.64rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-tab-active,
+.mobile-tab-more[data-state="open"] {
+  color: var(--accent-12);
+  background: var(--accent-a3);
+}
+
+.mobile-tab-active .mobile-tab-mark,
+.mobile-tab-more[data-state="open"] .mobile-tab-mark {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+/* O reset global tira o realce nativo de toque; isto ocupa o lugar dele. */
+.mobile-tab:active {
+  transform: scale(0.94);
+}
+
+.mobile-more-panel {
+  display: flex;
+  width: min(17rem, calc(100vw - 1.5rem));
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.mobile-more-segment {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.2rem;
+  padding: 0.2rem;
+  border: 1px solid var(--sand-a5);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-panel-solid) 72%, transparent);
+}
+
+.mobile-more-segment-option {
+  display: inline-flex;
+  min-height: 2.2rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--gray-11);
+  font: inherit;
+  font-size: var(--font-size-1);
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    color 180ms ease,
+    background 180ms ease;
+}
+
+.mobile-more-segment-option-active {
+  color: var(--accent-12);
+  background: var(--accent-a4);
+  box-shadow: inset 0 0 0 1px var(--accent-a5);
+}
+
+.mobile-more-accents {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.mobile-more-accent {
+  position: relative;
+  display: inline-flex;
+  width: 2.2rem;
+  height: 2.2rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--sand-a5);
+  border-radius: 999px;
+  background: transparent;
+  cursor: pointer;
+  transition:
+    box-shadow 180ms ease,
+    transform 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.mobile-more-accent-active {
+  box-shadow: 0 0 0 2px var(--accent-a7);
+}
+
+.mobile-more-accent:active {
+  transform: scale(0.92);
+}
+
+.mobile-more-accent-swatch {
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 999px;
+}
+
+.mobile-more-accent-check {
+  position: absolute;
+  color: #fff;
+  filter: drop-shadow(0 1px 1px rgb(0 0 0 / 45%));
+}
+
+.mobile-more-divider {
+  height: 1px;
+  margin: 0;
+  border: 0;
+  background: var(--sand-a5);
+}
+
+.mobile-more-item {
+  display: flex;
+  min-height: 2.5rem;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0 0.6rem;
+  border: 0;
+  border-radius: 0.7rem;
+  background: transparent;
+  color: var(--gray-12);
+  font: inherit;
+  font-size: var(--font-size-2);
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background 180ms ease,
+    color 180ms ease;
+}
+
+.mobile-more-item:hover {
+  background: var(--accent-a3);
+}
+
+.mobile-more-item:active {
+  background: var(--accent-a4);
+}
+
+.mobile-more-item-danger {
+  color: var(--red-11);
+}
+
+.mobile-more-item-danger:hover,
+.mobile-more-item-danger:active {
+  background: var(--red-a3);
+}
+
+@media (max-width: 820px) {
+  .mobile-tabbar {
+    display: block;
+    position: fixed;
+    right: max(var(--space-3), env(safe-area-inset-right));
+    bottom: max(var(--space-3), env(safe-area-inset-bottom));
+    left: max(var(--space-3), env(safe-area-inset-left));
+    /* Acima do player dock (35) e do header (40). */
+    z-index: 45;
   }
 }
 
@@ -1132,12 +1349,30 @@ a:hover > .brand-mark {
 
   .player-dock {
     right: var(--space-3);
-    bottom: var(--space-3);
     left: var(--space-3);
   }
 
   .player-dock-card {
     padding: var(--space-3);
+  }
+}
+
+/*
+ * Espaco da barra inferior. Precisa vir depois das regras base de `.player-dock`
+ * e `.has-player-dock`: mesma especificidade, entao quem ganha e a ultima.
+ */
+@media (max-width: 820px) {
+  .app-background {
+    padding-bottom: calc(5rem + env(safe-area-inset-bottom));
+  }
+
+  /* Com o player aberto, ele empilha acima da barra. */
+  .has-player-dock {
+    padding-bottom: calc(10rem + env(safe-area-inset-bottom));
+  }
+
+  .player-dock {
+    bottom: calc(4.15rem + max(var(--space-3), env(safe-area-inset-bottom)));
   }
 }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1369,7 +1369,78 @@ a:hover > .brand-mark {
     0 20px 60px -34px var(--sand-a12),
     inset 0 1px 0 color-mix(in srgb, #fff 18%, transparent);
   backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
   pointer-events: auto;
+}
+
+.player-dock-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
+/* A faixa inteira e o link para o Spotify — o alvo grande do dock. */
+.player-dock-link {
+  display: block;
+  min-width: 0;
+  flex: 1 1 16rem;
+  border-radius: var(--radius-3);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    background 180ms ease,
+    transform 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.player-dock-link:not(.is-static):hover {
+  background: var(--accent-a3);
+}
+
+.player-dock-link:not(.is-static):active {
+  transform: scale(0.985);
+}
+
+.player-dock-actions {
+  flex: 0 0 auto;
+}
+
+/*
+ * Os dois utilitarios ganham caixa propria: no `ghost` do Radix o botao e so o
+ * icone com 4px de respiro (e uma margem negativa para compensar), alvo pequeno
+ * demais para o dedo. Aqui o alvo cresce sem o icone crescer junto.
+ */
+.player-dock-actions .player-dock-action {
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  margin: 0;
+  border-radius: 999px;
+  color: var(--gray-11);
+}
+
+.player-dock-actions .player-dock-action:active {
+  transform: scale(0.94);
+}
+
+/*
+ * O unico uso de acento no dock: o progresso. Vale o destaque porque e o unico
+ * dado que muda sozinho enquanto a barra fica na tela.
+ */
+.player-dock-progress {
+  overflow: hidden;
+  height: 3px;
+  margin-top: var(--space-2);
+  border-radius: 999px;
+  background: var(--sand-a4);
+}
+
+.player-dock-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent-9);
+  transition: width 600ms ease;
 }
 
 .mini-player-next {
@@ -1427,8 +1498,69 @@ a:hover > .brand-mark {
     left: var(--space-3);
   }
 
+  /*
+   * Abaixo de 640px o dock para de ser a versao desktop encolhida. Ele vira uma
+   * barra de uma linha: capa, titulo e artista (uma linha cada), dois
+   * utilitarios de 44px e o progresso como filete no rodape. Altura e o recurso
+   * escasso aqui — o dock divide a base da tela com a barra de navegacao.
+   */
   .player-dock-card {
-    padding: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .player-dock-row {
+    flex-wrap: nowrap;
+    gap: var(--space-2);
+  }
+
+  .player-dock-link {
+    flex: 1 1 auto;
+  }
+
+  /* O botao "Abrir" sai: no toque o alvo passa a ser a barra inteira. */
+  .player-dock-open {
+    display: none;
+  }
+
+  /* "Tocando agora" e redundante: o dock so existe quando esta tocando. */
+  .player-dock-card .section-eyebrow {
+    display: none;
+  }
+
+  .player-dock-card .truncate-2 {
+    -webkit-line-clamp: 1;
+  }
+
+  .player-dock-card .mini-player-thumb {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
+
+  .player-dock-actions .player-dock-action {
+    width: 2.75rem;
+    min-width: 2.75rem;
+    height: 2.75rem;
+  }
+
+  /*
+   * Dispensar precisa ser facil de proposito e dificil por acidente: alvo cheio
+   * de 44px, mas separado do atualizar por um filete e afastado dele. O resto da
+   * barra e link, entao o toque que erra cai no Spotify, nao no X.
+   */
+  .player-dock-actions .player-dock-dismiss {
+    position: relative;
+    margin-left: var(--space-2);
+    background: var(--sand-a3);
+  }
+
+  .player-dock-actions .player-dock-dismiss::before {
+    content: "";
+    position: absolute;
+    top: 25%;
+    bottom: 25%;
+    left: calc(var(--space-2) * -0.5);
+    width: 1px;
+    background: var(--sand-a5);
   }
 }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -926,43 +926,63 @@ a:hover > .brand-mark {
 
 /* ---------- Card de perfil unificado ---------- */
 
+/*
+ * Base = coluna estreita (mobile); o bloco de 768px reconstroi a versao larga.
+ * `--profile-pad` guarda o padding do Card porque a faixa de numeros precisa da
+ * mesma medida em negativo para sangrar ate a borda.
+ */
 .profile-card {
-  padding: clamp(var(--space-3), 1.4vw, var(--space-4));
+  --profile-pad: var(--space-4);
+  padding: var(--profile-pad);
   box-shadow:
     0 1px 0 color-mix(in srgb, #fff 12%, transparent) inset,
     0 14px 38px -34px var(--sand-a9);
 }
 
-.profile-eyebrow {
-  font-size: 0.62rem;
-  letter-spacing: 0.16em;
-  opacity: 0.75;
-}
-
 .profile-card::after {
-  top: clamp(3rem, 5vw, 4.6rem);
+  top: 3.4rem;
   right: auto;
-  left: clamp(3rem, 5vw, 4.4rem);
-  width: clamp(5.2rem, 10vw, 7.5rem);
-  height: clamp(5.2rem, 10vw, 7.5rem);
+  left: 3.4rem;
+  width: 5.8rem;
+  height: 5.8rem;
   transform: translate(-50%, -50%);
   background: radial-gradient(circle, var(--accent-a3), transparent 70%);
-  opacity: 0.34;
-  filter: blur(16px);
+  opacity: 0.28;
+  filter: blur(14px);
 }
 
+/* Identidade, numeros e acao: um bloco por linha, na ordem de leitura. */
 .profile-layout {
   position: relative;
   z-index: 1;
+  display: grid;
+  gap: var(--space-4);
 }
 
 .profile-identity {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
   min-width: 0;
-  flex: 1 1 auto;
 }
 
+.profile-heading {
+  min-width: 0;
+}
+
+/* Nomes longos quebram em duas linhas (`truncate-2`); o break evita que um
+ * nome sem espacos empurre a largura do card. */
 .profile-name {
-  max-width: 22ch;
+  overflow-wrap: break-word;
+}
+
+.profile-meta {
+  margin-top: 0.3rem;
+  color: var(--accent-11);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
 .avatar-ring {
@@ -987,26 +1007,19 @@ a:hover > .brand-mark {
   height: 64px !important;
 }
 
-@media (min-width: 640px) {
-  .avatar-ring .skeleton {
-    width: 80px !important;
-    height: 80px !important;
-  }
-}
-
 /*
- * Base = card empilhado (mobile). Aqui a faixa NAO pode ter `flex-basis`: o eixo
- * principal do `.profile-layout` e vertical, entao um basis viraria altura fixa
- * e a caixa ficaria alta e vazia, com os numeros boiando no meio.
+ * Faixa de numeros. No mobile ela sangra ate a borda do card: sem as laterais,
+ * a moldura da faixa para de repetir a moldura do card e a linha vira uma
+ * secao do encarte em vez de uma caixa dentro de outra. O padding devolvido
+ * mantem o primeiro numero alinhado com o nome.
  */
 .stat-strip {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  width: 100%;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   min-width: 0;
-  overflow: hidden;
-  border: 1px solid var(--sand-a5);
-  border-radius: var(--radius-3);
+  margin-inline: calc(var(--profile-pad) * -1);
+  padding-inline: calc(var(--profile-pad) - var(--space-2));
+  border-block: 1px solid var(--sand-a5);
   background:
     linear-gradient(180deg, var(--accent-a1), transparent),
     color-mix(in srgb, var(--color-panel-solid) 80%, transparent);
@@ -1019,62 +1032,124 @@ a:hover > .brand-mark {
   flex-direction: column;
   justify-content: center;
   min-width: 0;
-  padding: clamp(var(--space-2), 1.2vw, var(--space-3));
+  padding: var(--space-3) var(--space-2);
 }
 
 .stat-cell + .stat-cell {
   border-left: 1px solid var(--sand-a5);
 }
 
+/* O numero e o conteudo da celula; o rotulo e legenda. */
 .stat-cell .stat-value {
   font-family: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
   font-variation-settings: normal;
   font-feature-settings: "tnum" 1;
   font-weight: 600;
+  font-size: clamp(1.05rem, 4.4vw, 1.35rem);
   line-height: 1;
   letter-spacing: -0.03em;
 }
 
-/*
- * A partir daqui o card vira linha. 768px e o breakpoint `sm` do Radix, usado no
- * `direction={{ initial: "column", sm: "row" }}` do Profile — os dois precisam
- * bater, senao existe uma faixa de larguras com o layout empilhado e o CSS de
- * desktop valendo ao mesmo tempo.
- */
-@media (min-width: 768px) {
-  .stat-strip {
-    flex: 0 1 20rem;
-    align-self: center;
-    width: auto;
-    max-width: 21rem;
-  }
+.stat-cell .stat-label {
+  margin-top: 0.4rem;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  line-height: 1.1;
+  text-transform: uppercase;
 }
 
-/* Card empilhado: tudo que so faz sentido antes do layout virar linha. */
-@media (max-width: 767px) {
+/*
+ * Unica acao do card. No toque ela vale a largura inteira e a altura minima de
+ * alvo (44px); o `:active` e obrigatorio porque o reset global apaga o realce
+ * nativo e no celular nao existe `:hover`.
+ */
+.profile-action {
+  display: flex;
+}
+
+.profile-action .rt-Button {
+  --base-button-height: 2.75rem;
+  width: 100%;
+  font-size: var(--font-size-3);
+  transition:
+    background 180ms ease,
+    transform 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.profile-action .rt-Button:active {
+  transform: scale(0.97);
+}
+
+.profile-action .skeleton {
+  width: 100% !important;
+}
+
+/*
+ * A partir daqui o card vira linha: identidade e acao empilhadas a esquerda,
+ * faixa de numeros a direita ocupando as duas linhas.
+ */
+@media (min-width: 768px) {
   .profile-card {
-    padding: var(--space-4);
+    --profile-pad: clamp(var(--space-3), 1.4vw, var(--space-4));
   }
 
   .profile-card::after {
-    top: 3.4rem;
-    left: 3.4rem;
-    width: 5.8rem;
-    height: 5.8rem;
-    opacity: 0.28;
-    filter: blur(14px);
+    top: clamp(3rem, 5vw, 4.6rem);
+    left: clamp(3rem, 5vw, 4.4rem);
+    width: clamp(5.2rem, 10vw, 7.5rem);
+    height: clamp(5.2rem, 10vw, 7.5rem);
+    opacity: 0.34;
+    filter: blur(16px);
+  }
+
+  .profile-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 20rem);
+    grid-template-areas:
+      "identity stats"
+      "action stats";
+    align-content: center;
+    column-gap: var(--space-6);
+    row-gap: var(--space-3);
   }
 
   .profile-identity {
-    align-items: flex-start;
+    grid-area: identity;
+    gap: var(--space-4);
+  }
+
+  .profile-action {
+    grid-area: action;
+    justify-self: start;
+  }
+
+  .stat-strip {
+    grid-area: stats;
+    align-self: center;
+    margin-inline: 0;
+    padding-inline: 0;
+    overflow: hidden;
+    border: 1px solid var(--sand-a5);
+    border-radius: var(--radius-3);
   }
 
   .stat-cell {
-    padding: var(--space-3) var(--space-2);
+    padding: clamp(var(--space-2), 1.2vw, var(--space-3));
   }
 
-  .stat-cell .stat-value {
-    font-size: clamp(0.9rem, 3.6vw, 1.05rem);
+  .avatar-ring .skeleton {
+    width: 80px !important;
+    height: 80px !important;
+  }
+
+  .profile-action .rt-Button {
+    --base-button-height: var(--space-6);
+    width: auto;
+    font-size: var(--font-size-2);
+  }
+
+  .profile-action .skeleton {
+    width: 9.5rem !important;
   }
 }
 

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -9,10 +9,16 @@ import { ThemeToggle } from "../components/Layout/ThemeToggle";
 import { LoginButton } from "../features/auth/LoginButton";
 import { isAuthenticated } from "../features/auth/auth";
 
+// O estudio de imagem entra como uma linha so: no app tambem e um unico lugar
+// (um botao, um modal), onde poster e mosaico sao abas do mesmo formulario.
 const highlights: Array<[string, string]> = [
   ["Top artistas", "Seu ranking dos artistas mais ouvidos."],
   ["Top faixas", "As músicas que você mais repete."],
   ["Biblioteca", "Suas faixas, álbuns e shows salvos."],
+  [
+    "Pôster e mosaico",
+    "Um pôster do seu ranking ou um mosaico de capas e artistas, para baixar.",
+  ],
 ];
 
 export const Login = () => {


### PR DESCRIPTION
Redesenho mobile-first da navegacao, do card de perfil e do player, mais a
inclusao do estudio de imagem na tela de login. Inclui a correcao de um bug do
player.

## Por que

As passadas anteriores de responsividade trataram sintoma: ajustaram
espacamento e tamanho de alvo mantendo o layout do desktop comprimido. O
problema era estrutural, entao aqui o criterio passou a ser frequencia de uso e
alcance do polegar.

## O que muda

### Navegacao (`17bbcba`)

O cabecalho era a versao desktop dobrada em duas linhas: oito alvos disputando a
faixa do topo, num sticky de ~104px.

A navegacao primaria desceu para uma barra fixa embaixo (Inicio, Busca,
Biblioteca, Mais) e as acoes de configuracao foram para o menu "Mais". O
cabecalho ficou em uma linha com marca e player — o que liberou espaco para o
nome do app voltar a aparecer no mobile, revertendo um compromisso registrado
antes.

Alvos de 46px, acima do minimo de 44px.

### Card de perfil (`75a71e6`)

- A leitura comecava pelo eyebrow "Conectado ao Spotify", que nao informa nada.
- A acao primaria (abrir o estudio de imagem) era o **menor** alvo do card: 32px,
  na terceira linha, sem feedback de toque.
- A faixa de numeros tinha hierarquia invertida: no mobile o valor ficava menor
  que o texto de corpo.

Agora a base descreve a coluna estreita e um unico `@media (min-width: 768px)`
reconstroi a versao larga.

### Player (`6021cd6`, `9fb811a`, `ba5f325`)

**Bug corrigido:** com o player aberto embaixo, o X nao o devolvia ao icone do
header — ele so sumia quando a musica parava. `AppShell` calculava
`showPlayerDock` mas nunca passava isso ao `PlayerDock`, que decidia sozinho
olhando so `isPlaying`. Agora o dock e renderizado condicionalmente, com
`showPlayerDock` como fonte unica de verdade.

A dispensa **nao** e desfeita na troca de faixa (a fila anda sozinha; reabrir o
dock a cada tres minutos em cima da barra de navegacao provoca toque errado). Ela
e desfeita quando a reproducao para e volta, que e intencao do usuario.

No redesenho, a faixa inteira do dock virou o link para o Spotify: o alvo
primario passou de um botao de 24px para ~60% da barra.

### Login (`c4de8e7`)

O card lateral lista o que o app entrega e nao mencionava o estudio de imagem.
Entrou como uma linha so, porque no app tambem e um lugar so (um botao, um modal,
duas abas). A copy foi conferida contra `features/imageStudio/` para nao prometer
o que nao existe.

## Verificacao

- `npm run build` (`tsc && vite build`) passa.
- Ordem de cascata dos overrides de empilhamento (dock sobre a barra de
  navegacao) conferida por numero de linha: as regras base vem antes, os
  overrides no fim do arquivo.

## Nao verificado

**Nada foi visto em navegador.** Vale conferir em 320px e 390px: a altura do dock
e o encaixe dele com a barra de navegacao (a folga foi calculada, nao observada),
a sangria da faixa de numeros do perfil, e o contraste do rotulo do plano nos
tres acentos e nos dois temas.

## Fora de escopo, encontrado no caminho

- "Seguindo" no card de perfil usa `followedArtists.artists.items.length`,
  limitado pela pagina da API (~20); `SpotifyPaged.total` daria o numero real.
- `PlayerNavControl` recebe `showDock`, mas so e renderizado quando
  `!showPlayerDock` — a prop e sempre `false` ali.

---

## Sobre esta branch

Mesmos seis commits do PR para `main`, aplicados por cherry-pick sobre
`main_cloudfare`. Nenhum conflito.

Todas as mudancas sao do client, entao a camada de plataforma (`worker/`,
`wrangler.toml`, scripts `cf:*`) nao foi tocada. Verificado alem do build:
`client/src` ficou **identico** ao da branch de `main`, e `wrangler deploy
--dry-run` continua passando.
