### PR TITLE
refactor(marca): renomeia para SonarStats e corrige o dominio nas imagens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 node_modules
 .env
 .netlify
+
+# A documentacao e local e NUNCA vai para o GitHub. O unico arquivo publico
+# de documentacao e o README.md da raiz.
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ node_modules
 # A documentacao e local e NUNCA vai para o GitHub. O unico arquivo publico
 # de documentacao e o README.md da raiz.
 docs/
+
+# Artefatos locais do wrangler (a alternativa Cloudflare vive em main_cloudfare)
+.dev.vars
+.wrangler

--- a/README.md
+++ b/README.md
@@ -1,8 +1,114 @@
-# spotifysplit
-Spotifysplit is a simple fullstack app connected to Spotify via OAUTH 2.0 to see all kinds of music stats. Built for practice. Currently in progress, building it in public. Feel free to fork and use as you like. 
-frotend: Vite + TypeScript + React + TailWindCSS,
-backend: Node.js + Express.
+# Spotifysplit
 
+A personal web app that shows your Spotify listening stats — the ones the
+official app doesn't surface. Built for practice, not for profit.
 
+**Live:** https://spotfysplit.netlify.app
 
+You log in with your own Spotify account. The app reads your data and never
+writes to it.
 
+## Features
+
+- **Log in with Spotify** — OAuth 2.0 Authorization Code flow. The login happens
+  on Spotify's side; the app never sees your password.
+- **Top artists and top tracks** — ranked, across three time ranges (last 4
+  weeks, last 6 months, last year).
+- **Recently played** — your latest listening history.
+- **Library** — saved tracks, saved albums and the artists you follow.
+- **Playlists** — your playlists and their full track lists.
+- **Search** — artists, tracks and albums.
+- **Detail pages** — for any artist, track or album, including related artists.
+- **Now playing** — a dock showing the current track, with a link back to
+  Spotify.
+- **Image studio** — turn your stats into a shareable image:
+  - a **poster** with your ranked top artists or tracks, in 9:16 (story) or 4:5
+    (post);
+  - a **mosaic**, a square grid (2×2 up to 6×6) of artist photos or album
+    covers.
+
+  Both let you pick the time range and an accent color, and export as PNG or
+  JPG. Sharing uses the browser's native share sheet when it supports files;
+  otherwise the image downloads and the caption is copied for you.
+- **Themes** — light and dark, plus a configurable accent color (amber, green or
+  red) that applies across the whole app.
+
+## Stack
+
+**Frontend:** Vite, React, TypeScript, Radix Themes, TailwindCSS, React Query,
+React Router, Framer Motion.
+
+**Auth backend:** three serverless functions handling the OAuth exchange
+(`/api/login`, `/api/callback`, `/api/refresh_token`) plus `/api/logout`. They
+exist only because the Spotify client secret can't ship to the browser —
+everything else talks to the Spotify Web API directly from the client.
+
+Deployed on **Netlify**, with the frontend and the functions on the same origin.
+A complete **Cloudflare Workers** alternative lives on the `main_cloudfare`
+branch and can be deployed at any time.
+
+For local development an **Express** server mirrors the same `/api` routes.
+
+## Running locally
+
+You'll need Node.js 20+ and an app registered in the
+[Spotify Developer Dashboard](https://developer.spotify.com/dashboard).
+
+**1. Register the local redirect URI** in your Spotify app settings:
+
+```
+http://127.0.0.1:3000/api/callback
+```
+
+**2. Create `.env` in the project root** (see `.env.example`):
+
+```env
+PORT=3000
+CLIENT_ID=your_client_id
+CLIENT_SECRET=your_client_secret
+REDIRECT_URI=http://127.0.0.1:3000/api/callback
+CLIENT_URL=http://127.0.0.1:5173
+SPOTIFY_SCOPES=user-read-private user-read-email user-read-recently-played user-top-read user-follow-read user-follow-modify user-library-read user-read-playback-state user-read-currently-playing playlist-read-private playlist-read-collaborative playlist-modify-public
+```
+
+**3. Create `client/.env`** (see `client/.env.example`):
+
+```env
+VITE_API_URL=http://127.0.0.1:3000/api
+```
+
+**4. Install and run:**
+
+```bash
+npm install
+npm install --prefix client
+npm run dev
+```
+
+The frontend runs on `http://127.0.0.1:5173` and the auth server on
+`http://127.0.0.1:3000`.
+
+### Use `127.0.0.1`, not `localhost`
+
+Spotify only accepts explicit loopback in redirect URIs, and browsers treat
+`localhost` and `127.0.0.1` as different hosts — a cookie set on one isn't sent
+to the other. Since the OAuth `state` check relies on a cookie, mixing the two
+breaks login with `state_mismatch` and silently returns you to the login screen.
+
+Use `127.0.0.1` everywhere: in both `.env` files and in the browser address bar.
+
+## Limitations
+
+This is a learning project, and it's honest about what the Web API can and can't
+give:
+
+- **Development Mode.** A Spotify app starts in Development Mode, where only
+  accounts you explicitly add in the dashboard can log in (up to 25). Lifting
+  that requires a quota extension request from Spotify.
+- **Genres belong to artists, not tracks.** Spotify classifies genres per
+  artist, using broad scene labels, so they can look odd next to a specific
+  song. The app shows them as-is rather than inventing a mapping.
+- **No "top albums" endpoint.** Album mosaics are derived from your top tracks,
+  deduplicated by album.
+- **Playback data is a snapshot.** "Now playing" polls periodically; it isn't a
+  live stream.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Spotifysplit
+# SonarStats
 
 A personal web app that shows your Spotify listening stats — the ones the
 official app doesn't surface. Built for practice, not for profit.
 
-**Live:** https://spotfysplit.netlify.app
+**Live:** https://sonarstats.netlify.app
 
 You log in with your own Spotify account. The app reads your data and never
 writes to it.

--- a/client/index.html
+++ b/client/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#17150f" />
     <meta
       name="description"
-      content="SpotfySplit — seus stats do Spotify: artistas, faixas e hábitos de escuta reunidos num só painel."
+      content="SonarStats — seus stats do Spotify: artistas, faixas e hábitos de escuta reunidos num só painel."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -15,7 +15,7 @@
       href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,500&family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;600;700&display=swap"
       rel="stylesheet"
     />
-    <title>SpotfySplit — seus stats do Spotify</title>
+    <title>SonarStats — seus stats do Spotify</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/components/Layout/AppShell.tsx
+++ b/client/src/components/Layout/AppShell.tsx
@@ -53,7 +53,7 @@ export const AppShell = ({ children, onLogout }: AppShellProps) => {
                 </Flex>
                 <Box className="brand-copy">
                   <Text as="p" size="2" className="brand-title">
-                    SpotfySplit
+                    SonarStats
                   </Text>
                   <Text as="p" size="1" color="gray">
                     Seus stats do Spotify

--- a/client/src/components/Layout/AppThemeProvider.tsx
+++ b/client/src/components/Layout/AppThemeProvider.tsx
@@ -25,14 +25,23 @@ type ThemeContextValue = {
   setAccent: (accent: AppAccent) => void;
 };
 
-const THEME_KEY = "spotifysplit_theme";
-const ACCENT_KEY = "spotifysplit_accent";
+const THEME_KEY = "sonarstats_theme";
+const ACCENT_KEY = "sonarstats_accent";
+
+// Chaves usadas antes do rename. So sao lidas, nunca gravadas: sem isso quem ja
+// usava o app perderia tema e cor de acento na primeira visita apos a troca.
+const LEGACY_THEME_KEY = "spotifysplit_theme";
+const LEGACY_ACCENT_KEY = "spotifysplit_accent";
+
+const readStored = (key: string, legacyKey: string) =>
+  window.localStorage.getItem(key) ?? window.localStorage.getItem(legacyKey);
+
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 const getInitialTheme = (): AppTheme => {
   if (typeof window === "undefined") return "dark";
 
-  const storedTheme = window.localStorage.getItem(THEME_KEY);
+  const storedTheme = readStored(THEME_KEY, LEGACY_THEME_KEY);
   if (storedTheme === "light" || storedTheme === "dark") return storedTheme;
 
   return window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -46,7 +55,7 @@ const isAppAccent = (value: string | null): value is AppAccent =>
 const getInitialAccent = (): AppAccent => {
   if (typeof window === "undefined") return "amber";
 
-  const stored = window.localStorage.getItem(ACCENT_KEY);
+  const stored = readStored(ACCENT_KEY, LEGACY_ACCENT_KEY);
   return isAppAccent(stored) ? stored : "amber";
 };
 

--- a/client/src/features/imageStudio/ImageStudioDialog.tsx
+++ b/client/src/features/imageStudio/ImageStudioDialog.tsx
@@ -18,13 +18,19 @@ type StudioFormat = "poster" | "collage";
 
 const DEFAULT_PERIOD: SpotifyTopTimeRange = "medium_term";
 
-// Nome legado (a cor nasceu no poster); mantido para nao descartar a escolha de
-// quem ja usava o app.
-const STUDIO_COLOR_KEY = "spotifysplit_poster_color";
+// "poster" no nome e legado: a cor nasceu no poster e hoje vale para o estudio
+// inteiro. A chave antiga so e lida, nunca gravada, para nao descartar a escolha
+// de quem ja usava o app antes do rename.
+const STUDIO_COLOR_KEY = "sonarstats_studio_color";
+const LEGACY_STUDIO_COLOR_KEY = "spotifysplit_poster_color";
 
 const getInitialColor = (): string => {
   if (typeof window === "undefined") return defaultStudioColor;
-  const stored = window.localStorage.getItem(STUDIO_COLOR_KEY);
+
+  const stored =
+    window.localStorage.getItem(STUDIO_COLOR_KEY) ??
+    window.localStorage.getItem(LEGACY_STUDIO_COLOR_KEY);
+
   return stored && isValidHex(stored) ? stored : defaultStudioColor;
 };
 

--- a/client/src/features/imageStudio/collage/CollagePanel.tsx
+++ b/client/src/features/imageStudio/collage/CollagePanel.tsx
@@ -7,7 +7,7 @@
 import { useMemo, useRef, useState } from "react";
 import { Flex, SegmentedControl, Spinner, Switch, Text } from "@radix-ui/themes";
 import { useProfileOverview } from "../../../shared/api/queries";
-import { APP_NAME } from "../../../shared/constants/app";
+import { APP_BRAND, APP_NAME } from "../../../shared/constants/app";
 import { getTopTimeRangeOption } from "../../../shared/constants/timeRanges";
 import { useElementWidth } from "../../../shared/hooks/useElementWidth";
 import {
@@ -122,7 +122,7 @@ export const CollagePanel = ({
   const fileFormatConfig = imageFileFormats[fileFormat];
 
   const exportRequest = {
-    fileName: `spotifysplit-mosaico-${source}-${timeRange}-${gridSize}x${gridSize}.${fileFormatConfig.extension}`,
+    fileName: `${APP_BRAND}-mosaico-${source}-${timeRange}-${gridSize}x${gridSize}.${fileFormatConfig.extension}`,
     // O mosaico ja pinta o proprio fundo; isso cobre as bordas e da ao JPEG a
     // base opaca que ele exige.
     backgroundColor: buildStudioTheme(accentColor).backgroundColor,

--- a/client/src/features/imageStudio/poster/PosterCard.tsx
+++ b/client/src/features/imageStudio/poster/PosterCard.tsx
@@ -3,7 +3,7 @@
 // para que a captura nunca toque recurso cross-origin. Serve tanto para top
 // artistas quanto para top faixas (lista generica de itens).
 import { forwardRef } from "react";
-import { APP_DOMAIN } from "../../../shared/constants/app";
+import { APP_BRAND, APP_DOMAIN } from "../../../shared/constants/app";
 import { ShareFormatConfig } from "./formats";
 import { buildStudioTheme } from "../studioTheme";
 import styles from "./PosterCard.module.css";
@@ -127,7 +127,7 @@ export const PosterCard = forwardRef<HTMLDivElement, PosterCardProps>(
           <footer className={styles.footer}>
             <hr className={styles.divider} />
             <div className={styles.wordmarkRow}>
-              <span className={styles.wordmark}>SPOTIFYSPLIT</span>
+              <span className={styles.wordmark}>{APP_BRAND.toUpperCase()}</span>
               <EqualizerStatic />
             </div>
             <span className={styles.tagline}>{tagline}</span>

--- a/client/src/features/imageStudio/poster/PosterPanel.tsx
+++ b/client/src/features/imageStudio/poster/PosterPanel.tsx
@@ -17,7 +17,7 @@ import {
   useTopArtists,
   useTopTracks,
 } from "../../../shared/api/queries";
-import { APP_NAME } from "../../../shared/constants/app";
+import { APP_BRAND, APP_NAME } from "../../../shared/constants/app";
 import { getTopTimeRangeOption } from "../../../shared/constants/timeRanges";
 import {
   pickImageUrl,
@@ -142,7 +142,7 @@ export const PosterPanel = ({
   const fileFormatConfig = imageFileFormats[fileFormat];
 
   const exportRequest = {
-    fileName: `spotifysplit-top-${content}-${timeRange}.${fileFormatConfig.extension}`,
+    fileName: `${APP_BRAND}-top-${content}-${timeRange}.${fileFormatConfig.extension}`,
     // O poster ja pinta o proprio fundo; isso cobre as bordas e da ao JPEG a
     // base opaca que ele exige.
     backgroundColor: buildStudioTheme(accentColor).backgroundColor,

--- a/client/src/pages/AboutPage.tsx
+++ b/client/src/pages/AboutPage.tsx
@@ -30,13 +30,13 @@ type Topic = {
 const topics: Topic[] = [
   {
     icon: <MixIcon />,
-    title: "O que é o SpotfySplit",
+    title: "O que é o SonarStats",
     body: "Um projeto pessoal de desenvolvimento, criado pra testar na prática a Web API do Spotify e o fluxo de autenticação OAuth 2.0. Não é um produto comercial — é só pra aprendizado e brincadeira.",
   },
   {
     icon: <PersonIcon />,
     title: "Você entra pelo Spotify, não por aqui",
-    body: "Você não cria conta no SpotfySplit. O login acontece no próprio Spotify, via OAuth 2.0: você só autoriza o app a ler os seus dados de escuta direto da sua conta. Quem valida quem você é, é o Spotify.",
+    body: "Você não cria conta no SonarStats. O login acontece no próprio Spotify, via OAuth 2.0: você só autoriza o app a ler os seus dados de escuta direto da sua conta. Quem valida quem você é, é o Spotify.",
   },
   {
     icon: <LockClosedIcon />,
@@ -61,7 +61,7 @@ export const AboutPage = () => {
                 <EqualizerMark />
               </Flex>
               <Text size="2" className="brand-title">
-                SpotfySplit
+                SonarStats
               </Text>
             </Link>
           </Flex>
@@ -94,7 +94,7 @@ export const AboutPage = () => {
               color="gray"
               style={{ maxWidth: 620, lineHeight: 1.7 }}
             >
-              O SpotfySplit reúne os seus stats do Spotify num painel próprio. Por
+              O SonarStats reúne os seus stats do Spotify num painel próprio. Por
               trás disso, é um exercício de desenvolvimento com a Web API do
               Spotify e o fluxo OAuth 2.0.
             </Text>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -35,7 +35,7 @@ export const Login = () => {
               <EqualizerMark />
             </Flex>
             <Text size="2" className="brand-title">
-              SpotfySplit
+              SonarStats
             </Text>
           </Flex>
           <Flex align="center" gap="3">

--- a/client/src/shared/constants/app.ts
+++ b/client/src/shared/constants/app.ts
@@ -4,10 +4,8 @@
 // A marca e o sufixo ficam separados porque o rodape das imagens compoe os dois
 // com estilos diferentes (marca em Fraunces, dominio em mono).
 
-// A marca segue a grafia do dominio publicado (spotfysplit, sem o "i"), que e
-// tambem a que aparece no cabecalho do app.
-export const APP_NAME = "Spotifysplit";
-export const APP_BRAND = "spotfysplit";
+export const APP_NAME = "SonarStats";
+export const APP_BRAND = "sonarstats";
 export const APP_DOMAIN_SUFFIX = ".netlify.app";
 export const APP_DOMAIN = `${APP_BRAND}${APP_DOMAIN_SUFFIX}`;
 export const APP_URL = `https://${APP_DOMAIN}`;

--- a/client/src/shared/constants/app.ts
+++ b/client/src/shared/constants/app.ts
@@ -4,8 +4,10 @@
 // A marca e o sufixo ficam separados porque o rodape das imagens compoe os dois
 // com estilos diferentes (marca em Fraunces, dominio em mono).
 
+// A marca segue a grafia do dominio publicado (spotfysplit, sem o "i"), que e
+// tambem a que aparece no cabecalho do app.
 export const APP_NAME = "Spotifysplit";
-export const APP_BRAND = "spotifysplit";
-export const APP_DOMAIN_SUFFIX = ".onrender.com";
+export const APP_BRAND = "spotfysplit";
+export const APP_DOMAIN_SUFFIX = ".netlify.app";
 export const APP_DOMAIN = `${APP_BRAND}${APP_DOMAIN_SUFFIX}`;
 export const APP_URL = `https://${APP_DOMAIN}`;

--- a/client/src/shared/image/useImageExport.ts
+++ b/client/src/shared/image/useImageExport.ts
@@ -6,6 +6,7 @@
 
 import { useCallback, useState } from "react";
 import { toCanvas } from "html-to-image";
+import { APP_NAME } from "../constants/app";
 
 export type ImageExportStatus = "idle" | "working" | "success" | "error";
 
@@ -147,7 +148,7 @@ export const useImageExport = () => {
           try {
             await navigator.share({
               files: [file],
-              title: "Spotifysplit",
+              title: APP_NAME,
               text: request.shareText,
             });
             setStatus("success");

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "spotify-app",
+  "name": "sonarstats",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
Renomeia o app para **SonarStats**, corrige o dominio estampado nas imagens
exportadas, reescreve o README publico e impede que a documentacao local vá para
o GitHub.

## Por que renomear

As diretrizes de marca do Spotify vetam usar "Spotify" no nome do app, ou algo
parecido em som e grafia. `Spotifysplit` continha o nome inteiro e `Spotfysplit`
lia como um erro de digitacao dele — pior no mesmo criterio. Isso passa a
importar de verdade num pedido de extensao de quota, que e quando o Spotify
revisa o app.

A grafia tambem estava inconsistente em tres lugares: o codigo dizia
`Spotifysplit`, o cabecalho mostrava `SpotfySplit` e o dominio era `spotfysplit`.

## Bug corrigido: dominio morto nas imagens

`APP_DOMAIN_SUFFIX` ainda era `.onrender.com`. Isso compunha `APP_URL` e era
**estampado no rodape de todo poster e mosaico exportado**, alem dos links de
compartilhamento.

O deploy antigo do Render **continua respondendo HTTP 200**, entao nao era um
link quebrado: era uma cópia velha e funcional do app.

Trocar so o sufixo teria gerado `spotifysplit.netlify.app`, que da 404 — o
dominio real nao tem o "i". Por isso `APP_BRAND` mudou junto.

## Chaves de localStorage: renomeadas sem perder dados

As chaves continham o nome antigo. Renomear direto zeraria tema, cor de acento e
cor do estudio de quem ja usa o app. As novas (`sonarstats_*`) sao gravadas; as
antigas continuam sendo **lidas** uma vez, e somem sozinhas conforme as pessoas
voltam. E por isso que "spotifysplit" ainda aparece em tres pontos do codigo,
comentados como legado.

## Documentacao

- `docs/` entrou no `.gitignore`. Ela e local e nunca vai para o GitHub; antes
  estava apenas nao rastreada, entao um `git add .` distraido publicaria tudo.
- README publico reescrito: o anterior dizia "backend: Node.js + Express", o que
  deixou de valer quando o app migrou para funcoes serverless. Agora lista as
  features reais, a stack correta e as instrucoes locais com o prefixo `/api`.

## Verificacao

- `npm run build` (`tsc && vite build`) passa.
- Conferido no bundle publicado: `<title>` correto, o dominio composto bate com
  `sonarstats.netlify.app`, e as unicas ocorrencias do nome antigo sao as chaves
  legadas e a URL do repositorio.
- Escopos do README conferidos contra o `.env.example`.

## Pendencias

- A URL do GitHub no app (`GitHubNavButton.tsx`) aponta para o repositorio atual.
  Se o repositorio for renomeado, ela precisa mudar junto.
- `wrangler.toml` na `main_cloudfare` ainda tem `name = "spotifysplit"`.
- `SPOTIFY_SCOPES` ainda pede `user-follow-modify` e `playlist-modify-public`,
  que o app nunca usa. Cortar reduz o dano de um token vazado a somente leitura.
