### PR TITLE
refactor(profile): reequilibra a hierarquia do card de perfil

### DIFF
--- a/client/src/components/Layout/Skeleton.tsx
+++ b/client/src/components/Layout/Skeleton.tsx
@@ -47,20 +47,17 @@ export const CardGridSkeleton = ({
 export const ProfileSkeleton = () => (
   <Card className="hero-panel profile-card" mb="2">
     <Box className="profile-layout">
-      <Box className="profile-topline">
-        <Skeleton width="7rem" height="0.6rem" />
-        <Box className="profile-action">
-          <Skeleton radius="999px" />
-        </Box>
-      </Box>
-
       <Box className="profile-identity">
         <Box className="avatar-ring">
           <Skeleton width="64px" height="64px" radius="999px" />
         </Box>
 
-        <Box style={{ flex: "1 1 auto", minWidth: 0 }}>
+        <Box className="profile-heading" style={{ flex: "1 1 auto", minWidth: 0 }}>
+          <Skeleton width="7rem" height="0.68rem" />
           <Skeleton width="min(15rem, 62%)" height="1.65rem" />
+          <Box className="profile-action">
+            <Skeleton width="9.5rem" height="2.75rem" radius="999px" />
+          </Box>
         </Box>
       </Box>
 

--- a/client/src/components/Layout/Skeleton.tsx
+++ b/client/src/components/Layout/Skeleton.tsx
@@ -52,12 +52,13 @@ export const ProfileSkeleton = () => (
           <Skeleton width="64px" height="64px" radius="999px" />
         </Box>
 
-        <Box className="profile-heading" style={{ flex: "1 1 auto", minWidth: 0 }}>
+        <Box className="profile-heading">
           <Skeleton width="7rem" height="0.68rem" />
-          <Skeleton width="min(15rem, 62%)" height="1.65rem" />
-          <Box className="profile-action">
-            <Skeleton width="9.5rem" height="2.75rem" radius="999px" />
-          </Box>
+          <Skeleton width="min(15rem, 80%)" height="1.65rem" />
+        </Box>
+
+        <Box className="profile-action">
+          <Skeleton width="9.5rem" height="2.75rem" radius="999px" />
         </Box>
       </Box>
 

--- a/client/src/components/Layout/Skeleton.tsx
+++ b/client/src/components/Layout/Skeleton.tsx
@@ -42,36 +42,37 @@ export const CardGridSkeleton = ({
   </Grid>
 );
 
-// Espelha o layout do card de perfil: identidade, faixa de numeros e acao.
+// Espelha o layout do card de perfil: cabecalho com acao, identidade e faixa
+// de numeros.
 export const ProfileSkeleton = () => (
   <Card className="hero-panel profile-card" mb="2">
     <Box className="profile-layout">
+      <Box className="profile-topline">
+        <Skeleton width="7rem" height="0.6rem" />
+        <Box className="profile-action">
+          <Skeleton radius="999px" />
+        </Box>
+      </Box>
+
       <Box className="profile-identity">
         <Box className="avatar-ring">
           <Skeleton width="64px" height="64px" radius="999px" />
         </Box>
 
-        <Box className="profile-heading" style={{ flex: "1 1 auto" }}>
+        <Box style={{ flex: "1 1 auto", minWidth: 0 }}>
           <Skeleton width="min(15rem, 62%)" height="1.65rem" />
-          <Box mt="2">
-            <Skeleton width="7rem" height="0.6rem" />
-          </Box>
         </Box>
       </Box>
 
       <Box className="stat-strip">
         {Array.from({ length: 3 }).map((_, index) => (
           <Box className="stat-cell" key={index}>
-            <Skeleton width="60%" height="1.2rem" />
+            <Skeleton width="60%" height="1rem" />
             <Box mt="2">
-              <Skeleton width="78%" height="0.58rem" />
+              <Skeleton width="78%" height="0.62rem" />
             </Box>
           </Box>
         ))}
-      </Box>
-
-      <Box className="profile-action">
-        <Skeleton height="2.75rem" />
       </Box>
     </Box>
   </Card>

--- a/client/src/components/Profile/Profile.tsx
+++ b/client/src/components/Profile/Profile.tsx
@@ -39,13 +39,13 @@ export const Profile = () => {
     <Reveal>
       <Card className="hero-panel profile-card" mb="2">
         {/*
-         * Identidade (procedencia, nome e a acao do card) -> numeros.
+         * Identidade (plano, nome e a acao do card) -> numeros.
          *
-         * Os tres ficam na mesma coluna, ao lado do avatar: o plano descreve a
-         * conta e a acao age sobre ela, entao eles pertencem ao bloco de
-         * identidade. Espalhar isso numa linha de topo de largura total abria um
-         * vao enorme no desktop e deixava o rotulo pequeno pareado com um botao
-         * grande, sem relacao visual entre os dois.
+         * O plano e o nome formam um par colado; a acao fica fora dessa pilha,
+         * na propria linha do avatar. Dentro da pilha ela quebrava o ritmo do
+         * texto: a caixa de 44px do botao soma ~14px de respiro interno antes do
+         * rotulo, entao o vao ate o nome ficava muito maior que o do nome ate o
+         * plano, por mais que o `gap` fosse o mesmo.
          */}
         <Box className="profile-layout">
           <Box className="profile-identity">
@@ -66,10 +66,10 @@ export const Profile = () => {
               <Heading className="display-heading truncate-2 profile-name" size="6">
                 {profile.display_name}
               </Heading>
+            </Box>
 
-              <Box className="profile-action">
-                <ImageStudioDialog />
-              </Box>
+            <Box className="profile-action">
+              <ImageStudioDialog />
             </Box>
           </Box>
 

--- a/client/src/components/Profile/Profile.tsx
+++ b/client/src/components/Profile/Profile.tsx
@@ -16,8 +16,8 @@ const initialsOf = (name?: string) =>
     .toUpperCase() || "SS";
 
 // O plano e a unica informacao propria do usuario nessa linha; o resto era
-// texto de reforco. Juntar tudo num rotulo so libera a linha que o badge
-// ocupava, que na coluna estreita valia mais para a acao do card.
+// texto de reforco. Juntar tudo num rotulo so deixa a linha do topo curta o
+// bastante para dividir espaco com a acao do card.
 const connectionLabel = (product?: string) =>
   product ? `Spotify · ${product}` : "Spotify";
 
@@ -38,8 +38,22 @@ export const Profile = () => {
   return (
     <Reveal>
       <Card className="hero-panel profile-card" mb="2">
-        {/* Quem e voce -> seus numeros -> o que da para fazer. */}
+        {/*
+         * Cabecalho (procedencia + acao) -> quem e voce -> seus numeros.
+         * A acao mora na linha do topo, e nao no rodape do card: ali ela e uma
+         * ferramenta de canto, em largura natural, sem disputar atencao com o
+         * nome nem virar um bloco de rodape do tamanho do card.
+         */}
         <Box className="profile-layout">
+          <Box className="profile-topline">
+            <Text as="p" className="profile-meta">
+              {connectionLabel(profile.product)}
+            </Text>
+            <Box className="profile-action">
+              <ImageStudioDialog />
+            </Box>
+          </Box>
+
           <Box className="profile-identity">
             <Box className="avatar-ring">
               <Avatar
@@ -50,14 +64,9 @@ export const Profile = () => {
               />
             </Box>
 
-            <Box className="profile-heading">
-              <Heading className="display-heading truncate-2 profile-name" size="6">
-                {profile.display_name}
-              </Heading>
-              <Text as="p" className="profile-meta">
-                {connectionLabel(profile.product)}
-              </Text>
-            </Box>
+            <Heading className="display-heading truncate-2 profile-name" size="6">
+              {profile.display_name}
+            </Heading>
           </Box>
 
           <Box className="stat-strip">
@@ -71,10 +80,6 @@ export const Profile = () => {
                 </Text>
               </Box>
             ))}
-          </Box>
-
-          <Box className="profile-action">
-            <ImageStudioDialog />
           </Box>
         </Box>
       </Card>

--- a/client/src/components/Profile/Profile.tsx
+++ b/client/src/components/Profile/Profile.tsx
@@ -39,21 +39,15 @@ export const Profile = () => {
     <Reveal>
       <Card className="hero-panel profile-card" mb="2">
         {/*
-         * Cabecalho (procedencia + acao) -> quem e voce -> seus numeros.
-         * A acao mora na linha do topo, e nao no rodape do card: ali ela e uma
-         * ferramenta de canto, em largura natural, sem disputar atencao com o
-         * nome nem virar um bloco de rodape do tamanho do card.
+         * Identidade (procedencia, nome e a acao do card) -> numeros.
+         *
+         * Os tres ficam na mesma coluna, ao lado do avatar: o plano descreve a
+         * conta e a acao age sobre ela, entao eles pertencem ao bloco de
+         * identidade. Espalhar isso numa linha de topo de largura total abria um
+         * vao enorme no desktop e deixava o rotulo pequeno pareado com um botao
+         * grande, sem relacao visual entre os dois.
          */}
         <Box className="profile-layout">
-          <Box className="profile-topline">
-            <Text as="p" className="profile-meta">
-              {connectionLabel(profile.product)}
-            </Text>
-            <Box className="profile-action">
-              <ImageStudioDialog />
-            </Box>
-          </Box>
-
           <Box className="profile-identity">
             <Box className="avatar-ring">
               <Avatar
@@ -64,9 +58,19 @@ export const Profile = () => {
               />
             </Box>
 
-            <Heading className="display-heading truncate-2 profile-name" size="6">
-              {profile.display_name}
-            </Heading>
+            <Box className="profile-heading">
+              <Text as="p" className="profile-meta">
+                {connectionLabel(profile.product)}
+              </Text>
+
+              <Heading className="display-heading truncate-2 profile-name" size="6">
+                {profile.display_name}
+              </Heading>
+
+              <Box className="profile-action">
+                <ImageStudioDialog />
+              </Box>
+            </Box>
           </Box>
 
           <Box className="stat-strip">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -939,9 +939,9 @@ a:hover > .brand-mark {
     0 14px 38px -34px var(--sand-a9);
 }
 
-/* O brilho acompanha o avatar, que agora comeca abaixo da linha do topo. */
+/* O brilho acompanha o avatar, que volta ao topo do card. */
 .profile-card::after {
-  top: 6.4rem;
+  top: 3.7rem;
   right: auto;
   left: 3.2rem;
   width: 5.8rem;
@@ -952,21 +952,12 @@ a:hover > .brand-mark {
   filter: blur(14px);
 }
 
-/* Cabecalho, identidade e numeros: um bloco por linha, na ordem de leitura. */
+/* Identidade e numeros: um bloco por linha, na ordem de leitura. */
 .profile-layout {
   position: relative;
   z-index: 1;
   display: grid;
-  gap: var(--space-3);
-}
-
-/* Linha de topo do encarte: procedencia a esquerda, ferramenta a direita. */
-.profile-topline {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  min-width: 0;
+  gap: var(--space-4);
 }
 
 .profile-identity {
@@ -976,6 +967,20 @@ a:hover > .brand-mark {
   min-width: 0;
 }
 
+/*
+ * Coluna de texto ao lado do avatar: plano, nome e acao empilhados e alinhados
+ * a esquerda. Empilhar em vez de espalhar mantem os tres como um bloco so — era
+ * isso que faltava quando o plano e a acao dividiam uma linha de largura total,
+ * cada um grudado numa borda do card.
+ */
+.profile-heading {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.3rem;
+}
+
 /* Nomes longos quebram em duas linhas (`truncate-2`); o break evita que um
  * nome sem espacos empurre a largura do card. */
 .profile-name {
@@ -983,14 +988,17 @@ a:hover > .brand-mark {
   overflow-wrap: break-word;
 }
 
-/* Some antes de espremer o botao ao lado: e reforco, nao dado unico. */
+/*
+ * Eyebrow da identidade. Sobe de 0.62 para 0.68rem com menos entreletra: a 10px
+ * e 0.16em ele lia como ruido acima do nome, nao como informacao.
+ */
 .profile-meta {
-  min-width: 0;
+  max-width: 100%;
   overflow: hidden;
   color: var(--accent-11);
-  font-size: 0.62rem;
+  font-size: 0.68rem;
   font-weight: 700;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.13em;
   text-overflow: ellipsis;
   text-transform: uppercase;
   white-space: nowrap;
@@ -1073,23 +1081,27 @@ a:hover > .brand-mark {
 }
 
 /*
- * Unica acao do card, no canto do cabecalho. Largura natural com fonte contida
- * mantem o peso visual baixo, e a altura de 2.75rem (44px) garante o alvo de
- * toque sem virar bloco. O `:active` e obrigatorio porque o reset global apaga
- * o realce nativo e no celular nao existe `:hover`.
+ * Unica acao do card, logo abaixo do nome e na mesma coluna: assim ela pertence
+ * ao bloco de identidade em vez de flutuar num canto.
+ *
+ * Mantem 2.75rem (44px) de alvo no toque, mas com o rotulo em `font-size-2`. A
+ * 44px de altura com fonte de 12px a pilula parecia inflada — o problema de
+ * tamanho era proporcao entre caixa e texto, nao a altura em si. O `:active` e
+ * obrigatorio porque o reset global apaga o realce nativo e no celular nao
+ * existe `:hover`.
  */
 .profile-action {
   display: flex;
-  flex: none;
+  margin-top: 0.15rem;
 }
 
 .profile-action .rt-Button {
   --base-button-height: 2.75rem;
-  gap: var(--space-1);
-  padding-inline: var(--space-3);
+  gap: var(--space-2);
+  padding-inline: var(--space-4);
   border-radius: 999px;
-  font-size: var(--font-size-1);
-  letter-spacing: 0.02em;
+  font-size: var(--font-size-2);
+  letter-spacing: 0.01em;
   transition:
     background 180ms ease,
     transform 140ms cubic-bezier(0.22, 1, 0.36, 1);
@@ -1115,7 +1127,7 @@ a:hover > .brand-mark {
   }
 
   .profile-card::after {
-    top: clamp(5.4rem, 8vw, 7rem);
+    top: clamp(3.4rem, 6vw, 4.8rem);
     left: clamp(3rem, 5vw, 4.4rem);
     width: clamp(5.2rem, 10vw, 7.5rem);
     height: clamp(5.2rem, 10vw, 7.5rem);
@@ -1123,27 +1135,23 @@ a:hover > .brand-mark {
     filter: blur(16px);
   }
 
+  /*
+   * Duas colunas na mesma linha: identidade a esquerda, numeros a direita. Sao
+   * dois filhos, entao o auto-placement do grid ja resolve — sem areas
+   * nomeadas. Uma faixa de largura total aqui em cima jogava o rotulo numa
+   * borda e a acao na outra, com um vao enorme no meio.
+   */
   .profile-layout {
     grid-template-columns: minmax(0, 1fr) minmax(0, 20rem);
-    grid-template-areas:
-      "topline topline"
-      "identity stats";
-    align-content: center;
+    align-items: center;
     column-gap: var(--space-6);
-    row-gap: var(--space-4);
-  }
-
-  .profile-topline {
-    grid-area: topline;
   }
 
   .profile-identity {
-    grid-area: identity;
     gap: var(--space-4);
   }
 
   .stat-strip {
-    grid-area: stats;
     align-self: center;
     margin-inline: 0;
     padding-inline: 0;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -960,25 +960,52 @@ a:hover > .brand-mark {
   gap: var(--space-4);
 }
 
+/*
+ * Avatar, texto e acao. Em telas muito estreitas a acao desce para uma linha
+ * propria; a partir de 26rem ela cabe ao lado, encostada a direita e centrada
+ * com o avatar — que e onde o espaco vazio estava sobrando.
+ */
 .profile-identity {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    "avatar heading"
+    "action action";
   align-items: center;
-  gap: var(--space-3);
+  column-gap: var(--space-3);
+  row-gap: var(--space-3);
   min-width: 0;
 }
 
+.avatar-ring {
+  grid-area: avatar;
+}
+
+.profile-heading {
+  grid-area: heading;
+}
+
+.profile-action {
+  grid-area: action;
+}
+
+@media (min-width: 26rem) {
+  .profile-identity {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-areas: "avatar heading action";
+  }
+}
+
 /*
- * Coluna de texto ao lado do avatar: plano, nome e acao empilhados e alinhados
- * a esquerda. Empilhar em vez de espalhar mantem os tres como um bloco so — era
- * isso que faltava quando o plano e a acao dividiam uma linha de largura total,
- * cada um grudado numa borda do card.
+ * Plano e nome sao um par: o vao entre eles e o menor do card, para lerem como
+ * uma coisa so e nao como duas linhas soltas.
  */
 .profile-heading {
   display: flex;
   min-width: 0;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.3rem;
+  gap: 0.1rem;
 }
 
 /* Nomes longos quebram em duas linhas (`truncate-2`); o break evita que um
@@ -989,13 +1016,18 @@ a:hover > .brand-mark {
 }
 
 /*
- * Eyebrow da identidade. Sobe de 0.62 para 0.68rem com menos entreletra: a 10px
- * e 0.16em ele lia como ruido acima do nome, nao como informacao.
+ * Eyebrow da identidade, em cinza. Ele estava em acento e disputava com o botao
+ * logo abaixo — dois elementos ambar num bloco de tres linhas. A direcao visual
+ * do projeto ja pede eyebrow em cinza, com o acento reservado para o que e
+ * acionavel.
+ *
+ * Sobe de 0.62 para 0.68rem com menos entreletra: a 10px e 0.16em ele lia como
+ * ruido acima do nome, nao como informacao.
  */
 .profile-meta {
   max-width: 100%;
   overflow: hidden;
-  color: var(--accent-11);
+  color: var(--gray-11);
   font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.13em;
@@ -1081,18 +1113,16 @@ a:hover > .brand-mark {
 }
 
 /*
- * Unica acao do card, logo abaixo do nome e na mesma coluna: assim ela pertence
- * ao bloco de identidade em vez de flutuar num canto.
+ * Unica acao do card. Mantem 2.75rem (44px) de alvo no toque, com o rotulo em
+ * `font-size-2`: a 44px de altura com fonte de 12px a pilula parecia inflada.
  *
- * Mantem 2.75rem (44px) de alvo no toque, mas com o rotulo em `font-size-2`. A
- * 44px de altura com fonte de 12px a pilula parecia inflada — o problema de
- * tamanho era proporcao entre caixa e texto, nao a altura em si. O `:active` e
- * obrigatorio porque o reset global apaga o realce nativo e no celular nao
- * existe `:hover`.
+ * O anel interno da contorno a pilula. Sem ele, o fundo `soft` sobre o painel
+ * escuro do card fica quase invisivel e o botao le como texto solto, nao como
+ * controle. O `:active` e obrigatorio porque o reset global apaga o realce
+ * nativo e no celular nao existe `:hover`.
  */
 .profile-action {
   display: flex;
-  margin-top: 0.15rem;
 }
 
 .profile-action .rt-Button {
@@ -1100,6 +1130,7 @@ a:hover > .brand-mark {
   gap: var(--space-2);
   padding-inline: var(--space-4);
   border-radius: 999px;
+  box-shadow: inset 0 0 0 1px var(--accent-a5);
   font-size: var(--font-size-2);
   letter-spacing: 0.01em;
   transition:

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -939,10 +939,11 @@ a:hover > .brand-mark {
     0 14px 38px -34px var(--sand-a9);
 }
 
+/* O brilho acompanha o avatar, que agora comeca abaixo da linha do topo. */
 .profile-card::after {
-  top: 3.4rem;
+  top: 6.4rem;
   right: auto;
-  left: 3.4rem;
+  left: 3.2rem;
   width: 5.8rem;
   height: 5.8rem;
   transform: translate(-50%, -50%);
@@ -951,12 +952,21 @@ a:hover > .brand-mark {
   filter: blur(14px);
 }
 
-/* Identidade, numeros e acao: um bloco por linha, na ordem de leitura. */
+/* Cabecalho, identidade e numeros: um bloco por linha, na ordem de leitura. */
 .profile-layout {
   position: relative;
   z-index: 1;
   display: grid;
-  gap: var(--space-4);
+  gap: var(--space-3);
+}
+
+/* Linha de topo do encarte: procedencia a esquerda, ferramenta a direita. */
+.profile-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-width: 0;
 }
 
 .profile-identity {
@@ -966,23 +976,24 @@ a:hover > .brand-mark {
   min-width: 0;
 }
 
-.profile-heading {
-  min-width: 0;
-}
-
 /* Nomes longos quebram em duas linhas (`truncate-2`); o break evita que um
  * nome sem espacos empurre a largura do card. */
 .profile-name {
+  min-width: 0;
   overflow-wrap: break-word;
 }
 
+/* Some antes de espremer o botao ao lado: e reforco, nao dado unico. */
 .profile-meta {
-  margin-top: 0.3rem;
+  min-width: 0;
+  overflow: hidden;
   color: var(--accent-11);
   font-size: 0.62rem;
   font-weight: 700;
   letter-spacing: 0.16em;
+  text-overflow: ellipsis;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .avatar-ring {
@@ -1008,22 +1019,19 @@ a:hover > .brand-mark {
 }
 
 /*
- * Faixa de numeros. No mobile ela sangra ate a borda do card: sem as laterais,
- * a moldura da faixa para de repetir a moldura do card e a linha vira uma
- * secao do encarte em vez de uma caixa dentro de outra. O padding devolvido
- * mantem o primeiro numero alinhado com o nome.
+ * Faixa de numeros. No mobile so o fio de cima sangra ate a borda do card: sem
+ * fundo e sem moldura fechada, a faixa deixa de ser caixa dentro de caixa e
+ * vira o rodape do encarte. O padding devolvido mantem o primeiro numero
+ * alinhado com o avatar.
  */
 .stat-strip {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   min-width: 0;
   margin-inline: calc(var(--profile-pad) * -1);
-  padding-inline: calc(var(--profile-pad) - var(--space-2));
-  border-block: 1px solid var(--sand-a5);
-  background:
-    linear-gradient(180deg, var(--accent-a1), transparent),
-    color-mix(in srgb, var(--color-panel-solid) 80%, transparent);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, #fff 18%, transparent);
+  padding-inline: calc(var(--profile-pad) - var(--space-3));
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--sand-a5);
 }
 
 .stat-cell {
@@ -1032,62 +1040,74 @@ a:hover > .brand-mark {
   flex-direction: column;
   justify-content: center;
   min-width: 0;
-  padding: var(--space-3) var(--space-2);
+  padding-inline: var(--space-3);
 }
 
 .stat-cell + .stat-cell {
   border-left: 1px solid var(--sand-a5);
 }
 
-/* O numero e o conteudo da celula; o rotulo e legenda. */
+/*
+ * O numero fica na mesma altura do texto de corpo: a monoespacada tabular e o
+ * peso 600 ja dao presenca, entao subir o corpo so faz a faixa pesar mais que
+ * o nome do usuario. O rotulo acompanha de perto para o par ler como uma
+ * unidade, e nao como numero + legenda perdida.
+ */
 .stat-cell .stat-value {
   font-family: "JetBrains Mono", ui-monospace, "SFMono-Regular", monospace;
   font-variation-settings: normal;
   font-feature-settings: "tnum" 1;
   font-weight: 600;
-  font-size: clamp(1.05rem, 4.4vw, 1.35rem);
+  font-size: 1rem;
   line-height: 1;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.02em;
 }
 
 .stat-cell .stat-label {
-  margin-top: 0.4rem;
-  font-size: 0.58rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
+  margin-top: 0.35rem;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
   line-height: 1.1;
   text-transform: uppercase;
 }
 
 /*
- * Unica acao do card. No toque ela vale a largura inteira e a altura minima de
- * alvo (44px); o `:active` e obrigatorio porque o reset global apaga o realce
- * nativo e no celular nao existe `:hover`.
+ * Unica acao do card, no canto do cabecalho. Largura natural com fonte contida
+ * mantem o peso visual baixo, e a altura de 2.75rem (44px) garante o alvo de
+ * toque sem virar bloco. O `:active` e obrigatorio porque o reset global apaga
+ * o realce nativo e no celular nao existe `:hover`.
  */
 .profile-action {
   display: flex;
+  flex: none;
 }
 
 .profile-action .rt-Button {
   --base-button-height: 2.75rem;
-  width: 100%;
-  font-size: var(--font-size-3);
+  gap: var(--space-1);
+  padding-inline: var(--space-3);
+  border-radius: 999px;
+  font-size: var(--font-size-1);
+  letter-spacing: 0.02em;
   transition:
     background 180ms ease,
     transform 140ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .profile-action .rt-Button:active {
-  transform: scale(0.97);
+  transform: scale(0.94);
 }
 
+/* O esqueleto reserva a mesma pilula da acao (o Skeleton usa estilo inline). */
 .profile-action .skeleton {
-  width: 100% !important;
+  width: 9.5rem !important;
+  height: 2.75rem !important;
 }
 
 /*
- * A partir daqui o card vira linha: identidade e acao empilhadas a esquerda,
- * faixa de numeros a direita ocupando as duas linhas.
+ * A partir daqui o card vira linha: cabecalho cruzando o topo inteiro,
+ * identidade a esquerda e faixa de numeros a direita.
  */
 @media (min-width: 768px) {
   .profile-card {
@@ -1095,7 +1115,7 @@ a:hover > .brand-mark {
   }
 
   .profile-card::after {
-    top: clamp(3rem, 5vw, 4.6rem);
+    top: clamp(5.4rem, 8vw, 7rem);
     left: clamp(3rem, 5vw, 4.4rem);
     width: clamp(5.2rem, 10vw, 7.5rem);
     height: clamp(5.2rem, 10vw, 7.5rem);
@@ -1106,11 +1126,15 @@ a:hover > .brand-mark {
   .profile-layout {
     grid-template-columns: minmax(0, 1fr) minmax(0, 20rem);
     grid-template-areas:
-      "identity stats"
-      "action stats";
+      "topline topline"
+      "identity stats";
     align-content: center;
     column-gap: var(--space-6);
-    row-gap: var(--space-3);
+    row-gap: var(--space-4);
+  }
+
+  .profile-topline {
+    grid-area: topline;
   }
 
   .profile-identity {
@@ -1118,23 +1142,22 @@ a:hover > .brand-mark {
     gap: var(--space-4);
   }
 
-  .profile-action {
-    grid-area: action;
-    justify-self: start;
-  }
-
   .stat-strip {
     grid-area: stats;
     align-self: center;
     margin-inline: 0;
     padding-inline: 0;
-    overflow: hidden;
+    padding-block: clamp(var(--space-2), 1.2vw, var(--space-3));
     border: 1px solid var(--sand-a5);
     border-radius: var(--radius-3);
   }
 
   .stat-cell {
-    padding: clamp(var(--space-2), 1.2vw, var(--space-3));
+    padding-inline: clamp(var(--space-2), 1.2vw, var(--space-3));
+  }
+
+  .stat-cell .stat-value {
+    font-size: 1.05rem;
   }
 
   .avatar-ring .skeleton {
@@ -1142,14 +1165,14 @@ a:hover > .brand-mark {
     height: 80px !important;
   }
 
+  /* Sem toque, o alvo de 44px vira peso desnecessario no canto. */
   .profile-action .rt-Button {
-    --base-button-height: var(--space-6);
-    width: auto;
+    --base-button-height: 2.25rem;
     font-size: var(--font-size-2);
   }
 
   .profile-action .skeleton {
-    width: 9.5rem !important;
+    height: 2.25rem !important;
   }
 }
 

--- a/client/src/pages/ArtistsPage.tsx
+++ b/client/src/pages/ArtistsPage.tsx
@@ -10,6 +10,7 @@ import { LoadingState } from "../components/Layout/LoadingState";
 import { Reveal } from "../components/Layout/Reveal";
 import { Section } from "../components/Layout/Section";
 import { TrackRankingList } from "../components/Ranking/RankingLists";
+import { isFeatureGoneError } from "../shared/api/errors";
 import { useArtist, useArtistTopTracks, useRelatedArtists } from "../shared/api/queries";
 import { formatGenresLabel, formatNumber } from "../utils/format";
 
@@ -20,6 +21,7 @@ const ArtistPage = () => {
   const topTracksQuery = useArtistTopTracks(id);
   const relatedQuery = useRelatedArtists(id);
   const relatedArtists = relatedQuery.data?.artists ?? [];
+  const relatedUnavailable = isFeatureGoneError(relatedQuery.error);
   const topTracks = topTracksQuery.data?.tracks ?? [];
 
   if (artistQuery.isLoading) {
@@ -44,7 +46,12 @@ const ArtistPage = () => {
     <AppShell>
       <Reveal>
       <Card className="hero-panel" size="3">
-        <Grid columns={{ initial: "1", md: "280px 1fr" }} gap="5" align="center">
+        {/*
+         * `auto` e nao uma largura fixa: a coluna era de 280px para um avatar
+         * que o Radix limita a 160px no `size="9"`, entao sobravam ~120px de
+         * coluna vazia entre a foto e o texto, alem do gap.
+         */}
+        <Grid columns={{ initial: "1", md: "auto 1fr" }} gap="5" align="center">
           <Avatar
             src={artist.images?.[0]?.url}
             fallback="SS"
@@ -94,12 +101,19 @@ const ArtistPage = () => {
         )}
       </Section>
 
+      {/*
+       * A secao some quando o endpoint esta indisponivel para o app, em vez de
+       * mostrar um erro permanente com "tentar novamente" que nunca vai dar
+       * certo: o Spotify descontinuou related-artists em 27/11/2024 e so apps
+       * com quota estendida aprovada antes disso mantiveram acesso.
+       */}
+      {!relatedUnavailable && (
       <Section title="Artistas relacionados" eyebrow="Continue explorando">
         {relatedQuery.isLoading && <LoadingState label="Carregando artistas relacionados" />}
         {relatedQuery.isError && (
           <FeatureUnavailableState
             title="Artistas relacionados indisponíveis"
-            description="O Spotify não retornou dados confiáveis para este artista ou não liberou esse endpoint para este app. Para evitar relações musicais erradas, esta seção não usa fallback."
+            description="O Spotify não retornou dados confiáveis para este artista. Para evitar relações musicais erradas, esta seção não usa fallback."
             onRetry={relatedQuery.refetch}
           />
         )}
@@ -119,6 +133,7 @@ const ArtistPage = () => {
           </Grid>
         )}
       </Section>
+      )}
     </AppShell>
   );
 };

--- a/client/src/shared/api/errors.ts
+++ b/client/src/shared/api/errors.ts
@@ -21,3 +21,15 @@ export class SpotifyAuthError extends SpotifyApiError {
 export const isAuthError = (error: unknown): boolean =>
   error instanceof SpotifyAuthError ||
   (error instanceof SpotifyApiError && error.status === 401);
+
+/*
+ * 403/404 numa rota que existe significam endpoint indisponivel para este app,
+ * nao falha momentanea. O Spotify descontinuou varios em 27/11/2024 (entre eles
+ * related-artists, recommendations e audio-features): so apps com quota
+ * estendida aprovada antes dessa data seguem com acesso.
+ *
+ * A UI usa isto para nao oferecer "tentar novamente" no que nunca vai voltar.
+ */
+export const isFeatureGoneError = (error: unknown): boolean =>
+  error instanceof SpotifyApiError &&
+  (error.status === 403 || error.status === 404);


### PR DESCRIPTION
Reequilibra a hierarquia do card de perfil no mobile. Responde a duas queixas
diretas: o botao "Gerar imagem" parecia fora do lugar, e os numeros estavam
grandes demais.

## Por que voltamos nesse card

Ele tinha sido redesenhado na task 12, e aquela passada corrigiu problemas reais
(a acao primaria era o menor alvo do card, os numeros ficavam menores que o texto
de corpo) — mas corrigiu demais. O resultado eram tres faixas empilhadas de
largura total, duas delas preenchidas, sem hierarquia entre si.

O problema agora nao era acessibilidade de toque. Era peso.

## Diagnostico (medido em ~390px)

- **A acao era o objeto mais pesado do card.** O botao de largura total ocupava
  ~15.700px² de superficie tingida — mais area preenchida que avatar, nome e
  eyebrow somados. Como era a ultima linha e ia de borda a borda, lia como
  rodape de formulario, nao como ferramenta do card.
- **A faixa de numeros era uma segunda superficie completa**: borda, gradiente de
  acento, fundo e `inset`, sangrando ate as bordas. A sangria tirou a
  caixa-dentro-de-caixa das laterais, mas manteve o preenchimento, que e o que
  pesa.
- **Os numeros escalavam sem teto util.** `clamp(1.05rem, 4.4vw, 1.35rem)` dava
  21,6px a partir de ~491px, ou seja, ainda dentro do layout estreito (<768px).

## O que mudou

**A acao virou uma pilula de largura natural na linha do topo**, ao lado do
rotulo do plano. Peso cai para ~5.200px² tingidos, um terco do anterior, sem
perder os 44px de alvo. Se o espaco apertar, quem cede e o eyebrow
(`text-overflow: ellipsis`); o botao nunca quebra (`flex: none`).

Alternativas descartadas por medida, nao por gosto: ao lado do nome nao cabe (em
320px sobrariam ~80px para o nome); icone sem rotulo custaria descoberta demais,
porque o estudio de imagem e a unica feature de export do app.

**Os numeros voltaram a `1rem`** (1,05rem no >=768px), sem `vw`. A presenca vem
da monoespacada tabular com peso 600, nao do corpo. A razao valor:rotulo cai de
1,85 para 1,61, entao o par le como uma unidade.

**A sangria continua, o preenchimento nao.** Sumiram fundo, gradiente, `inset` e
a borda de baixo; sobrou uma `border-top` sangrando ate as bordas do card. Vira
linha de rodape de encarte em vez de banda.

`ImageStudioDialog.tsx` nao foi tocado — tudo por CSS escopado em
`.profile-action`.

## Verificacao

- `npm run build` (`tsc && vite build`) passa.
- CSS confinado ao bloco do card de perfil (linhas 941-1152); nenhuma regra fora
  dele foi tocada ou reordenada, e nenhum breakpoint novo foi criado.
- Sem sobreposicao de arquivos com o PR #10 (rename).

## Nao verificado

**Nada foi visto em navegador.** As larguras que sustentam a decisao da linha do
topo (eyebrow ~128px, pilula ~118px em 320px) sao estimativas de metrica de
fonte, nao medicoes. Se a estimativa errou para mais, o efeito e o eyebrow
truncar antes do esperado em telas muito estreitas — o botao nao quebra. A
posicao nova do brilho `::after` tambem foi derivada por aritmetica.
