### PR TITLE
feat(tour): guia de onboarding para novos usuarios

### DIFF
--- a/client/src/components/Layout/AppShell.tsx
+++ b/client/src/components/Layout/AppShell.tsx
@@ -13,6 +13,7 @@ import { GitHubNavButton } from "./GitHubNavButton";
 import { MobileTabBar } from "./MobileTabBar";
 import { ThemeToggle } from "./ThemeToggle";
 import { useAuth } from "../../features/auth/useAuth";
+import { TourHelpButton, TourOverlay, TourProvider } from "../../features/tour";
 import { PlayerDock, PlayerNavControl, useNowPlaying } from "../Player/MiniPlayer";
 
 type AppShellProps = {
@@ -39,6 +40,7 @@ export const AppShell = ({ children, onLogout }: AppShellProps) => {
   }, [playerState.isPlaying]);
 
   return (
+    <TourProvider>
     <Box
       className={`app-background ${showPlayerDock ? "has-player-dock" : ""}`}
       minHeight="100vh"
@@ -102,6 +104,7 @@ export const AppShell = ({ children, onLogout }: AppShellProps) => {
                   />
                 </Box>
               )}
+              <TourHelpButton />
               <GitHubNavButton />
               <AccentPicker />
               <ThemeToggle />
@@ -129,6 +132,8 @@ export const AppShell = ({ children, onLogout }: AppShellProps) => {
         <PlayerDock state={playerState} onDismiss={() => setIsPlayerDockHidden(true)} />
       )}
       <MobileTabBar onLogout={handleLogout} />
+      <TourOverlay />
     </Box>
+    </TourProvider>
   );
 };

--- a/client/src/components/Layout/MobileMoreMenu.tsx
+++ b/client/src/components/Layout/MobileMoreMenu.tsx
@@ -5,6 +5,7 @@ import {
   GitHubLogoIcon,
   InfoCircledIcon,
   MoonIcon,
+  QuestionMarkCircledIcon,
   SunIcon,
 } from "@radix-ui/react-icons";
 import { Popover, Text } from "@radix-ui/themes";
@@ -12,6 +13,7 @@ import { Link } from "react-router-dom";
 import { useState } from "react";
 import { ACCENT_OPTIONS, useAppTheme } from "./AppThemeProvider";
 import { GITHUB_URL } from "./GitHubNavButton";
+import { useTour } from "../../features/tour";
 
 const THEME_OPTIONS = [
   { value: "light", label: "Claro", Icon: SunIcon },
@@ -25,6 +27,7 @@ const THEME_OPTIONS = [
 // mais e o clique-fora fecha os dois.
 export const MobileMoreMenu = ({ onLogout }: { onLogout: () => void }) => {
   const { theme, toggleTheme, accent, setAccent } = useAppTheme();
+  const tour = useTour();
   const [open, setOpen] = useState(false);
 
   const close = () => setOpen(false);
@@ -103,6 +106,20 @@ export const MobileMoreMenu = ({ onLogout }: { onLogout: () => void }) => {
         </div>
 
         <hr className="mobile-more-divider" />
+
+        {tour && (
+          <button
+            type="button"
+            className="mobile-more-item"
+            onClick={() => {
+              close();
+              tour.startTour();
+            }}
+          >
+            <QuestionMarkCircledIcon />
+            <span>Como funciona</span>
+          </button>
+        )}
 
         <Link to="/sobre" className="mobile-more-item" onClick={close}>
           <InfoCircledIcon />

--- a/client/src/components/Ranking/RankingLists.tsx
+++ b/client/src/components/Ranking/RankingLists.tsx
@@ -45,6 +45,7 @@ export const ArtistRankingList = ({
           role="button"
           tabIndex={0}
           className="ranking-row artist-ranking-row"
+          data-tour-id={index === 0 ? "ranking-row" : undefined}
           onClick={() => onSelect(artist)}
           onKeyDown={(event) => handleSelectableKeyDown(event, artist, onSelect)}
         >
@@ -79,7 +80,11 @@ export const ArtistRankingList = ({
             align="end"
             gap="1"
           >
-            <Badge variant="soft" radius="full">
+            <Badge
+              variant="soft"
+              radius="full"
+              data-tour-id={index === 0 ? "popularity" : undefined}
+            >
               {artist.popularity ?? "-"} pop.
             </Badge>
             {artist.followers?.total !== undefined && (

--- a/client/src/components/Ranking/TopRankingsOverview.tsx
+++ b/client/src/components/Ranking/TopRankingsOverview.tsx
@@ -16,7 +16,11 @@ export const TopRankingsOverview = () => {
   const tracks = tracksQuery.data?.items ?? [];
 
   return (
-    <Grid columns={{ initial: "1", lg: "1fr 1fr" }} gap={{ initial: "2", lg: "6" }}>
+    <Grid
+      data-tour-id="rankings"
+      columns={{ initial: "1", lg: "1fr 1fr" }}
+      gap={{ initial: "2", lg: "6" }}
+    >
       <Section
         title="Top artistas do último ano"
         titleTo="/top-artists"

--- a/client/src/features/imageStudio/ImageStudioDialog.tsx
+++ b/client/src/features/imageStudio/ImageStudioDialog.tsx
@@ -84,6 +84,7 @@ export const ImageStudioDialog = () => {
         maxWidth="900px"
         ref={contentRef}
         onOpenAutoFocus={focusActiveTab}
+        data-tour-id="studio-dialog"
       >
         <Dialog.Title>Gerar imagem</Dialog.Title>
         <Dialog.Description size="2" color="gray" mb="4">
@@ -94,7 +95,7 @@ export const ImageStudioDialog = () => {
           value={format}
           onValueChange={(value) => setFormat(value as StudioFormat)}
         >
-          <Tabs.List mb="4">
+          <Tabs.List mb="4" data-tour-id="studio-formats">
             <Tabs.Trigger value="poster">Pôster</Tabs.Trigger>
             <Tabs.Trigger value="collage">Mosaico</Tabs.Trigger>
           </Tabs.List>

--- a/client/src/features/imageStudio/ImageStudioDialog.tsx
+++ b/client/src/features/imageStudio/ImageStudioDialog.tsx
@@ -84,7 +84,6 @@ export const ImageStudioDialog = () => {
         maxWidth="900px"
         ref={contentRef}
         onOpenAutoFocus={focusActiveTab}
-        data-tour-id="studio-dialog"
       >
         <Dialog.Title>Gerar imagem</Dialog.Title>
         <Dialog.Description size="2" color="gray" mb="4">
@@ -95,7 +94,7 @@ export const ImageStudioDialog = () => {
           value={format}
           onValueChange={(value) => setFormat(value as StudioFormat)}
         >
-          <Tabs.List mb="4" data-tour-id="studio-formats">
+          <Tabs.List mb="4">
             <Tabs.Trigger value="poster">Pôster</Tabs.Trigger>
             <Tabs.Trigger value="collage">Mosaico</Tabs.Trigger>
           </Tabs.List>

--- a/client/src/features/tour/TourHelpButton.tsx
+++ b/client/src/features/tour/TourHelpButton.tsx
@@ -1,0 +1,31 @@
+// Porta permanente para o tour no header do desktop.
+//
+// Ela existe porque quem dispensa o convite nunca mais e reconvidado: sem um
+// caminho de volta explicito, "nunca mais" viraria "inacessivel".
+
+import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
+import { IconButton, Tooltip } from "@radix-ui/themes";
+import { useTour } from "./TourProvider";
+
+export const TourHelpButton = () => {
+  const tour = useTour();
+
+  // Sem provider (login, /sobre) o gatilho simplesmente nao existe.
+  if (!tour) return null;
+
+  return (
+    <Tooltip content="Como funciona">
+      <IconButton
+        type="button"
+        variant="soft"
+        color="gray"
+        highContrast
+        className="utility-icon-action clickable-control"
+        onClick={tour.startTour}
+        aria-label="Como funciona"
+      >
+        <QuestionMarkCircledIcon />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/client/src/features/tour/TourInvite.tsx
+++ b/client/src/features/tour/TourInvite.tsx
@@ -1,0 +1,55 @@
+// Convite: faixa no fluxo da home, entre o card de perfil e os rankings.
+//
+// Nao e modal, nem toast, nem ponto pulsante. Nao sobrepoe nada, rola junto com
+// a pagina e some ao ser respondido. O requisito e que o tour nao comece sem o
+// usuario mandar — entao o convite tem que ser recusavel com a mesma facilidade
+// com que e aceito: dois botoes de texto, nao um X de 16px.
+
+import { Button, Card, Text } from "@radix-ui/themes";
+import { Reveal } from "../../components/Layout/Reveal";
+import { useProfileOverview } from "../../shared/api/queries";
+import { useTour } from "./TourProvider";
+import "./tour.css";
+
+export const TourInvite = () => {
+  const tour = useTour();
+  const { data } = useProfileOverview();
+
+  // Espera o perfil resolver: sem isso o convite apareceria em cima dos
+  // skeletons e o usuario poderia aceitar antes de os alvos existirem. O React
+  // Query desduplica pela chave, entao nao ha requisicao extra.
+  if (!tour || tour.phase !== "invite" || !data) return null;
+
+  return (
+    <Reveal>
+      <Card className="hero-panel tour-invite" mb="2">
+        <Text as="p" size="1" weight="bold" className="section-eyebrow">
+          Primeira vez aqui?
+        </Text>
+
+        <Text as="p" size="2" color="gray" className="tour-invite-body">
+          Um guia rápido de {tour.stepCount} passos pelo que dá pra ver aqui — e
+          pelo que os números do Spotify significam.
+        </Text>
+
+        <div className="tour-invite-actions">
+          <Button
+            variant="soft"
+            className="clickable-control"
+            onClick={tour.startTour}
+          >
+            Ver o guia
+          </Button>
+          <Button
+            variant="ghost"
+            color="gray"
+            className="clickable-control"
+            onClick={tour.dismiss}
+          >
+            Agora não
+          </Button>
+        </div>
+      </Card>
+    </Reveal>
+  );
+};

--- a/client/src/features/tour/TourOverlay.tsx
+++ b/client/src/features/tour/TourOverlay.tsx
@@ -1,21 +1,14 @@
-// Scrim, spotlight e o card do passo.
+// Spotlight e o card do passo.
 //
-// Vai para um portal no `body` porque `.app-background` tem `isolation:
-// isolate`, ou seja, e um contexto de empilhamento proprio: de dentro dele
-// nenhum z-index alcanca o modal do Radix, que e irmao no `body`. E o passo de
-// dentro do estudio precisa ficar acima do modal.
+// Renderiza dentro da arvore do AppShell, sem portal. Portalizar para o `body`
+// so seria necessario para ficar acima do modal do Radix, e o tour deixou de
+// conviver com ele: de dentro do body o overlay perdia os tokens do tema (todos
+// escopados em `.radix-themes`) e herdava o `pointer-events: none` que o Dialog
+// poe no body.
 
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
-import { createPortal } from "react-dom";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
-import { useAppTheme } from "../../components/Layout/AppThemeProvider";
+import { Button, Card, Heading, Text } from "@radix-ui/themes";
 import { useAnchorRect } from "./useAnchorRect";
 import { useTour } from "./TourProvider";
 import "./tour.css";
@@ -48,11 +41,7 @@ const formatStepNumber = (index: number) => String(index + 1).padStart(2, "0");
 
 export const TourOverlay = () => {
   const tour = useTour();
-  const { theme, accent } = useAppTheme();
   const step = tour?.step ?? null;
-  // Precisa vir antes dos hooks de foco: dentro do modal o tour nao pode
-  // disputar o foco com o focus trap do Radix.
-  const stepInsideStudio = Boolean(step?.insideStudio);
   const rect = useAnchorRect(step?.anchors ?? null);
 
   const cardRef = useRef<HTMLDivElement>(null);
@@ -93,18 +82,15 @@ export const TourOverlay = () => {
   // `preventScroll` importa: sem ele o navegador rola ate o card e briga com o
   // `scrollIntoView` que ja levou o alvo para o centro.
   useLayoutEffect(() => {
-    if (!isRunning || stepInsideStudio) return;
+    if (!isRunning) return;
     cardRef.current?.focus({ preventScroll: true });
-  }, [isRunning, tour?.stepIndex, stepInsideStudio]);
+  }, [isRunning, tour?.stepIndex]);
 
   const handleWindowKey = useCallback(
     (event: KeyboardEvent) => {
       if (!tour) return;
 
-      // Dentro do estudio o Esc pertence ao modal: ele fecha, e o tour avanca
-      // sozinho por causa disso.
       if (event.key === "Escape") {
-        if (stepInsideStudio) return;
         event.stopPropagation();
         tour.dismiss();
         return;
@@ -112,7 +98,7 @@ export const TourOverlay = () => {
       if (event.key === "ArrowRight") tour.next();
       if (event.key === "ArrowLeft") tour.back();
     },
-    [tour, stepInsideStudio]
+    [tour]
   );
 
   useEffect(() => {
@@ -121,6 +107,8 @@ export const TourOverlay = () => {
     return () => window.removeEventListener("keydown", handleWindowKey);
   }, [isRunning, handleWindowKey]);
 
+  // Trap manual: o card e filho do mesmo root da app, entao `inert` no resto da
+  // arvore nao serve. Sao tres ou quatro botoes, o ciclo e barato.
   const trapTab = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "Tab") return;
 
@@ -148,21 +136,6 @@ export const TourOverlay = () => {
   const isFirst = stepIndex === 0;
   const isLast = stepIndex === stepCount - 1;
 
-  const insideStudio = Boolean(step.insideStudio);
-  const opensStudio = Boolean(step.opensStudio);
-
-  /*
-   * O escurecimento vem da sombra de 9999px do spotlight, nunca de um scrim por
-   * cima: um scrim de tela cheia cobriria o proprio buraco e o alvo destacado
-   * ficaria escuro tambem. O scrim solido so entra quando nao ha ancora.
-   *
-   * Dentro do estudio quem escurece e o overlay do proprio modal; aqui fica so
-   * o anel.
-   */
-  const spotlightClass = insideStudio
-    ? "tour-spotlight tour-spotlight-ring"
-    : "tour-spotlight";
-
   const spotlightStyle = rect
     ? {
         top: rect.top - 6,
@@ -172,18 +145,12 @@ export const TourOverlay = () => {
       }
     : undefined;
 
-  // O bloqueio de clique sai quando o passo espera uma acao do usuario: no
-  // passo que pede para abrir o estudio, o clique precisa chegar no botao.
-  const blocksClicks = !opensStudio && !insideStudio;
-
   let cardStyle: React.CSSProperties | undefined;
   let placement = "floating";
 
-  if (insideStudio) {
-    // Folha na base em qualquer largura: o modal ocupa o centro da tela, e um
-    // card ancorado nas abas cobriria justamente a previa que ele descreve.
-    placement = "sheet-bottom";
-  } else if (isMobile) {
+  if (isMobile) {
+    // A folha iria cobrir o alvo quando ele mesmo esta embaixo (os passos que
+    // apontam para a tab bar); nesse caso ela sobe para o topo.
     placement =
       rect && rect.top > window.innerHeight * 0.55 ? "sheet-top" : "sheet-bottom";
   } else if (rect) {
@@ -202,7 +169,10 @@ export const TourOverlay = () => {
       top = (viewportHeight - cardHeight) / 2;
     }
 
-    const maxTop = Math.max(VIEWPORT_MARGIN, viewportHeight - cardHeight - VIEWPORT_MARGIN);
+    const maxTop = Math.max(
+      VIEWPORT_MARGIN,
+      viewportHeight - cardHeight - VIEWPORT_MARGIN
+    );
     top = Math.min(Math.max(VIEWPORT_MARGIN, top), maxTop);
 
     const left = Math.min(
@@ -215,23 +185,18 @@ export const TourOverlay = () => {
     placement = "centered";
   }
 
-  return createPortal(
-    <Theme
-      appearance={theme}
-      accentColor={accent}
-      grayColor="sand"
-      radius="large"
-      scaling="100%"
-      hasBackground={false}
-      className="tour-theme"
-    >
-      {blocksClicks && <div className="tour-blocker" aria-hidden="true" />}
+  return (
+    <div className="tour-root">
+      {/* Transparente: engole cliques no app sem escurecer nada. Quem escurece
+          e a sombra do spotlight — um scrim por cima cobriria o proprio buraco
+          e o alvo destacado ficaria escuro tambem. */}
+      <div className="tour-blocker" aria-hidden="true" />
 
-      {/* Sem ancora nao ha spotlight, entao o escurecimento precisa vir daqui. */}
-      {!rect && !insideStudio && <div className="tour-scrim" aria-hidden="true" />}
+      {/* Sem ancora nao ha spotlight, entao o escurecimento vem daqui. */}
+      {!rect && <div className="tour-scrim" aria-hidden="true" />}
 
       {rect && (
-        <div className={spotlightClass} style={spotlightStyle} aria-hidden="true" />
+        <div className="tour-spotlight" style={spotlightStyle} aria-hidden="true" />
       )}
 
       <AnimatePresence mode="wait">
@@ -250,10 +215,10 @@ export const TourOverlay = () => {
             ref={cardRef}
             tabIndex={-1}
             role="dialog"
-            aria-modal={insideStudio ? undefined : true}
+            aria-modal="true"
             aria-labelledby={`tour-title-${step.id}`}
             aria-describedby={`tour-body-${step.id}`}
-            onKeyDown={insideStudio ? undefined : trapTab}
+            onKeyDown={trapTab}
           >
             <p className="tour-progress" aria-hidden="true">
               {Array.from({ length: stepCount }).map((_, index) => (
@@ -308,14 +273,13 @@ export const TourOverlay = () => {
                   </Button>
                 )}
                 <Button variant="soft" className="clickable-control" onClick={next}>
-                  {isLast ? "Concluir" : opensStudio ? "Pular" : "Avançar"}
+                  {isLast ? "Concluir" : "Avançar"}
                 </Button>
               </div>
             </div>
           </Card>
         </motion.div>
       </AnimatePresence>
-    </Theme>,
-    document.body
+    </div>
   );
 };

--- a/client/src/features/tour/TourOverlay.tsx
+++ b/client/src/features/tour/TourOverlay.tsx
@@ -1,0 +1,251 @@
+// Scrim, spotlight e o card do passo.
+//
+// Nao usa Popover do Radix: ele gerencia foco, clique-fora e dismiss de um jeito
+// que precisaria ser desligado item a item para conviver com o overlay, e no
+// mobile o comportamento certo nao e popover — e folha ancorada na borda.
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Button, Card, Heading, Text } from "@radix-ui/themes";
+import { useAnchorRect } from "./useAnchorRect";
+import { useTour } from "./TourProvider";
+import "./tour.css";
+
+const CARD_WIDTH = 384;
+const ANCHOR_GAP = 12;
+const VIEWPORT_MARGIN = 16;
+/** Espaco minimo abaixo do alvo para o card caber la; senao vai para cima. */
+const SPACE_FOR_CARD = 260;
+
+const MOBILE_QUERY = "(max-width: 820px)";
+
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== "undefined" && window.matchMedia(MOBILE_QUERY).matches
+  );
+
+  useEffect(() => {
+    const query = window.matchMedia(MOBILE_QUERY);
+    const update = () => setIsMobile(query.matches);
+
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return isMobile;
+};
+
+const formatStepNumber = (index: number) => String(index + 1).padStart(2, "0");
+
+export const TourOverlay = () => {
+  const tour = useTour();
+  const step = tour?.step ?? null;
+  const rect = useAnchorRect(step?.anchors ?? null);
+
+  const cardRef = useRef<HTMLDivElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const isMobile = useIsMobile();
+
+  const isRunning = tour?.phase === "running";
+
+  // Guarda para onde devolver o foco. O convite some ao ser aceito, entao o
+  // proprio botao que abriu o tour pode nao existir mais na saida — por isso a
+  // saida cai no card de perfil e nao neste elemento.
+  useEffect(() => {
+    if (!isRunning) return;
+    returnFocusRef.current = document.activeElement as HTMLElement | null;
+
+    return () => {
+      const fallback = document.querySelector<HTMLElement>(".profile-card");
+      const target = returnFocusRef.current;
+      const alive = target && document.body.contains(target) ? target : fallback;
+      alive?.focus?.({ preventScroll: true });
+    };
+  }, [isRunning]);
+
+  // `preventScroll` importa: sem ele o navegador rola ate o card e briga com o
+  // `scrollIntoView` que ja levou o alvo para o centro.
+  useLayoutEffect(() => {
+    if (!isRunning) return;
+    cardRef.current?.focus({ preventScroll: true });
+  }, [isRunning, tour?.stepIndex]);
+
+  const handleWindowKey = useCallback(
+    (event: KeyboardEvent) => {
+      if (!tour) return;
+
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        tour.dismiss();
+        return;
+      }
+      if (event.key === "ArrowRight") tour.next();
+      if (event.key === "ArrowLeft") tour.back();
+    },
+    [tour]
+  );
+
+  useEffect(() => {
+    if (!isRunning) return;
+    window.addEventListener("keydown", handleWindowKey);
+    return () => window.removeEventListener("keydown", handleWindowKey);
+  }, [isRunning, handleWindowKey]);
+
+  // Trap manual: o card e filho do mesmo root da app, entao `inert` no resto da
+  // arvore nao serve. Sao tres ou quatro botoes, o ciclo e barato.
+  const trapTab = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Tab") return;
+
+    const focusables = cardRef.current?.querySelectorAll<HTMLElement>(
+      "button:not([disabled])"
+    );
+    if (!focusables || focusables.length === 0) return;
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey && (active === first || active === cardRef.current)) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  if (!tour || !isRunning || !step) return null;
+
+  const { stepIndex, stepCount, next, back, dismiss } = tour;
+  const isFirst = stepIndex === 0;
+  const isLast = stepIndex === stepCount - 1;
+
+  // Sem alvo visivel, o card fica centrado e o spotlight nao aparece. Nenhum
+  // texto do tour usa "o botao ao lado", justamente para esse caso.
+  const spotlightStyle = rect
+    ? {
+        top: rect.top - 6,
+        left: rect.left - 6,
+        width: rect.width + 12,
+        height: rect.height + 12,
+      }
+    : undefined;
+
+  let cardStyle: React.CSSProperties | undefined;
+  let cardPlacement = "floating";
+
+  if (isMobile) {
+    // A folha iria cobrir o alvo quando ele mesmo esta embaixo (passos que
+    // apontam para a tab bar); nesse caso ela sobe para o topo.
+    cardPlacement =
+      rect && rect.top > window.innerHeight * 0.55 ? "sheet-top" : "sheet-bottom";
+  } else if (rect) {
+    const below = window.innerHeight - rect.bottom >= SPACE_FOR_CARD;
+    const left = Math.min(
+      Math.max(VIEWPORT_MARGIN, rect.left),
+      window.innerWidth - CARD_WIDTH - VIEWPORT_MARGIN
+    );
+
+    cardStyle = below
+      ? { top: rect.bottom + ANCHOR_GAP, left }
+      : { bottom: window.innerHeight - rect.top + ANCHOR_GAP, left };
+  } else {
+    cardPlacement = "centered";
+  }
+
+  return (
+    <div className="tour-root">
+      {/* Engole cliques no app. Clicar aqui nao fecha: fechar por clique-fora
+          num tour e o jeito classico de perder o usuario sem querer. */}
+      <div className="tour-scrim" aria-hidden="true" />
+
+      {rect && (
+        <div className="tour-spotlight" style={spotlightStyle} aria-hidden="true" />
+      )}
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={step.id}
+          className={`tour-card-shell tour-card-${cardPlacement}`}
+          style={cardStyle}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+        >
+          <Card
+            className="tour-card"
+            size="3"
+            ref={cardRef}
+            tabIndex={-1}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={`tour-title-${step.id}`}
+            aria-describedby={`tour-body-${step.id}`}
+            onKeyDown={trapTab}
+          >
+            <p className="tour-progress" aria-hidden="true">
+              {Array.from({ length: stepCount }).map((_, index) => (
+                <span
+                  key={index}
+                  className={index === stepIndex ? "tour-progress-current" : undefined}
+                >
+                  {formatStepNumber(index)}
+                </span>
+              ))}
+            </p>
+
+            <Heading
+              id={`tour-title-${step.id}`}
+              className="display-heading tour-title"
+              size="4"
+            >
+              {step.title}
+            </Heading>
+
+            <Text
+              as="p"
+              id={`tour-body-${step.id}`}
+              size="2"
+              color="gray"
+              className="tour-body"
+            >
+              {step.body}
+            </Text>
+
+            {step.note && (
+              <p className="tour-note serif-accent">{step.note}</p>
+            )}
+
+            <div className="tour-footer">
+              <Button
+                variant="ghost"
+                color="gray"
+                className="tour-exit clickable-control"
+                onClick={dismiss}
+              >
+                Sair
+              </Button>
+
+              <div className="tour-footer-nav">
+                {!isFirst && (
+                  <Button
+                    variant="ghost"
+                    color="gray"
+                    className="clickable-control"
+                    onClick={back}
+                  >
+                    Voltar
+                  </Button>
+                )}
+                <Button variant="soft" className="clickable-control" onClick={next}>
+                  {isLast ? "Concluir" : "Avançar"}
+                </Button>
+              </div>
+            </div>
+          </Card>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/client/src/features/tour/TourOverlay.tsx
+++ b/client/src/features/tour/TourOverlay.tsx
@@ -14,7 +14,8 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
-import { Button, Card, Heading, Text } from "@radix-ui/themes";
+import { Button, Card, Heading, Text, Theme } from "@radix-ui/themes";
+import { useAppTheme } from "../../components/Layout/AppThemeProvider";
 import { useAnchorRect } from "./useAnchorRect";
 import { useTour } from "./TourProvider";
 import "./tour.css";
@@ -47,7 +48,11 @@ const formatStepNumber = (index: number) => String(index + 1).padStart(2, "0");
 
 export const TourOverlay = () => {
   const tour = useTour();
+  const { theme, accent } = useAppTheme();
   const step = tour?.step ?? null;
+  // Precisa vir antes dos hooks de foco: dentro do modal o tour nao pode
+  // disputar o foco com o focus trap do Radix.
+  const stepInsideStudio = Boolean(step?.insideStudio);
   const rect = useAnchorRect(step?.anchors ?? null);
 
   const cardRef = useRef<HTMLDivElement>(null);
@@ -88,15 +93,18 @@ export const TourOverlay = () => {
   // `preventScroll` importa: sem ele o navegador rola ate o card e briga com o
   // `scrollIntoView` que ja levou o alvo para o centro.
   useLayoutEffect(() => {
-    if (!isRunning) return;
+    if (!isRunning || stepInsideStudio) return;
     cardRef.current?.focus({ preventScroll: true });
-  }, [isRunning, tour?.stepIndex]);
+  }, [isRunning, tour?.stepIndex, stepInsideStudio]);
 
   const handleWindowKey = useCallback(
     (event: KeyboardEvent) => {
       if (!tour) return;
 
+      // Dentro do estudio o Esc pertence ao modal: ele fecha, e o tour avanca
+      // sozinho por causa disso.
       if (event.key === "Escape") {
+        if (stepInsideStudio) return;
         event.stopPropagation();
         tour.dismiss();
         return;
@@ -104,7 +112,7 @@ export const TourOverlay = () => {
       if (event.key === "ArrowRight") tour.next();
       if (event.key === "ArrowLeft") tour.back();
     },
-    [tour]
+    [tour, stepInsideStudio]
   );
 
   useEffect(() => {
@@ -208,7 +216,15 @@ export const TourOverlay = () => {
   }
 
   return createPortal(
-    <div className="tour-root">
+    <Theme
+      appearance={theme}
+      accentColor={accent}
+      grayColor="sand"
+      radius="large"
+      scaling="100%"
+      hasBackground={false}
+      className="tour-theme"
+    >
       {blocksClicks && <div className="tour-blocker" aria-hidden="true" />}
 
       {/* Sem ancora nao ha spotlight, entao o escurecimento precisa vir daqui. */}
@@ -234,10 +250,10 @@ export const TourOverlay = () => {
             ref={cardRef}
             tabIndex={-1}
             role="dialog"
-            aria-modal="true"
+            aria-modal={insideStudio ? undefined : true}
             aria-labelledby={`tour-title-${step.id}`}
             aria-describedby={`tour-body-${step.id}`}
-            onKeyDown={trapTab}
+            onKeyDown={insideStudio ? undefined : trapTab}
           >
             <p className="tour-progress" aria-hidden="true">
               {Array.from({ length: stepCount }).map((_, index) => (
@@ -299,7 +315,7 @@ export const TourOverlay = () => {
           </Card>
         </motion.div>
       </AnimatePresence>
-    </div>,
+    </Theme>,
     document.body
   );
 };

--- a/client/src/features/tour/TourOverlay.tsx
+++ b/client/src/features/tour/TourOverlay.tsx
@@ -1,10 +1,18 @@
 // Scrim, spotlight e o card do passo.
 //
-// Nao usa Popover do Radix: ele gerencia foco, clique-fora e dismiss de um jeito
-// que precisaria ser desligado item a item para conviver com o overlay, e no
-// mobile o comportamento certo nao e popover — e folha ancorada na borda.
+// Vai para um portal no `body` porque `.app-background` tem `isolation:
+// isolate`, ou seja, e um contexto de empilhamento proprio: de dentro dele
+// nenhum z-index alcanca o modal do Radix, que e irmao no `body`. E o passo de
+// dentro do estudio precisa ficar acima do modal.
 
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { Button, Card, Heading, Text } from "@radix-ui/themes";
 import { useAnchorRect } from "./useAnchorRect";
@@ -14,8 +22,8 @@ import "./tour.css";
 const CARD_WIDTH = 384;
 const ANCHOR_GAP = 12;
 const VIEWPORT_MARGIN = 16;
-/** Espaco minimo abaixo do alvo para o card caber la; senao vai para cima. */
-const SPACE_FOR_CARD = 260;
+/** Altura suposta antes da primeira medida, so para o primeiro frame. */
+const CARD_HEIGHT_GUESS = 240;
 
 const MOBILE_QUERY = "(max-width: 820px)";
 
@@ -44,13 +52,11 @@ export const TourOverlay = () => {
 
   const cardRef = useRef<HTMLDivElement>(null);
   const returnFocusRef = useRef<HTMLElement | null>(null);
+  const [cardHeight, setCardHeight] = useState(CARD_HEIGHT_GUESS);
   const isMobile = useIsMobile();
 
   const isRunning = tour?.phase === "running";
 
-  // Guarda para onde devolver o foco. O convite some ao ser aceito, entao o
-  // proprio botao que abriu o tour pode nao existir mais na saida — por isso a
-  // saida cai no card de perfil e nao neste elemento.
   useEffect(() => {
     if (!isRunning) return;
     returnFocusRef.current = document.activeElement as HTMLElement | null;
@@ -62,6 +68,22 @@ export const TourOverlay = () => {
       alive?.focus?.({ preventScroll: true });
     };
   }, [isRunning]);
+
+  // A altura real do card decide se ele cabe acima ou abaixo da ancora. Sem
+  // medir, uma ancora mais alta que a viewport empurrava o card para fora da
+  // tela — era o passo dos rankings aparecendo cortado.
+  useLayoutEffect(() => {
+    const element = cardRef.current;
+    if (!element) return;
+
+    const measure = () => setCardHeight(element.offsetHeight);
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [isRunning, step?.id]);
 
   // `preventScroll` importa: sem ele o navegador rola ate o card e briga com o
   // `scrollIntoView` que ja levou o alvo para o centro.
@@ -91,8 +113,6 @@ export const TourOverlay = () => {
     return () => window.removeEventListener("keydown", handleWindowKey);
   }, [isRunning, handleWindowKey]);
 
-  // Trap manual: o card e filho do mesmo root da app, entao `inert` no resto da
-  // arvore nao serve. Sao tres ou quatro botoes, o ciclo e barato.
   const trapTab = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "Tab") return;
 
@@ -120,8 +140,21 @@ export const TourOverlay = () => {
   const isFirst = stepIndex === 0;
   const isLast = stepIndex === stepCount - 1;
 
-  // Sem alvo visivel, o card fica centrado e o spotlight nao aparece. Nenhum
-  // texto do tour usa "o botao ao lado", justamente para esse caso.
+  const insideStudio = Boolean(step.insideStudio);
+  const opensStudio = Boolean(step.opensStudio);
+
+  /*
+   * O escurecimento vem da sombra de 9999px do spotlight, nunca de um scrim por
+   * cima: um scrim de tela cheia cobriria o proprio buraco e o alvo destacado
+   * ficaria escuro tambem. O scrim solido so entra quando nao ha ancora.
+   *
+   * Dentro do estudio quem escurece e o overlay do proprio modal; aqui fica so
+   * o anel.
+   */
+  const spotlightClass = insideStudio
+    ? "tour-spotlight tour-spotlight-ring"
+    : "tour-spotlight";
+
   const spotlightStyle = rect
     ? {
         top: rect.top - 6,
@@ -131,42 +164,64 @@ export const TourOverlay = () => {
       }
     : undefined;
 
-  let cardStyle: React.CSSProperties | undefined;
-  let cardPlacement = "floating";
+  // O bloqueio de clique sai quando o passo espera uma acao do usuario: no
+  // passo que pede para abrir o estudio, o clique precisa chegar no botao.
+  const blocksClicks = !opensStudio && !insideStudio;
 
-  if (isMobile) {
-    // A folha iria cobrir o alvo quando ele mesmo esta embaixo (passos que
-    // apontam para a tab bar); nesse caso ela sobe para o topo.
-    cardPlacement =
+  let cardStyle: React.CSSProperties | undefined;
+  let placement = "floating";
+
+  if (insideStudio) {
+    // Folha na base em qualquer largura: o modal ocupa o centro da tela, e um
+    // card ancorado nas abas cobriria justamente a previa que ele descreve.
+    placement = "sheet-bottom";
+  } else if (isMobile) {
+    placement =
       rect && rect.top > window.innerHeight * 0.55 ? "sheet-top" : "sheet-bottom";
   } else if (rect) {
-    const below = window.innerHeight - rect.bottom >= SPACE_FOR_CARD;
+    const viewportHeight = window.innerHeight;
+    const spaceBelow = viewportHeight - rect.bottom - ANCHOR_GAP - VIEWPORT_MARGIN;
+    const spaceAbove = rect.top - ANCHOR_GAP - VIEWPORT_MARGIN;
+
+    let top: number;
+    if (spaceBelow >= cardHeight) {
+      top = rect.bottom + ANCHOR_GAP;
+    } else if (spaceAbove >= cardHeight) {
+      top = rect.top - ANCHOR_GAP - cardHeight;
+    } else {
+      // Ancora maior que a viewport (os dois rankings juntos, por exemplo):
+      // nao ha lado bom, entao o card centraliza.
+      top = (viewportHeight - cardHeight) / 2;
+    }
+
+    const maxTop = Math.max(VIEWPORT_MARGIN, viewportHeight - cardHeight - VIEWPORT_MARGIN);
+    top = Math.min(Math.max(VIEWPORT_MARGIN, top), maxTop);
+
     const left = Math.min(
       Math.max(VIEWPORT_MARGIN, rect.left),
-      window.innerWidth - CARD_WIDTH - VIEWPORT_MARGIN
+      Math.max(VIEWPORT_MARGIN, window.innerWidth - CARD_WIDTH - VIEWPORT_MARGIN)
     );
 
-    cardStyle = below
-      ? { top: rect.bottom + ANCHOR_GAP, left }
-      : { bottom: window.innerHeight - rect.top + ANCHOR_GAP, left };
+    cardStyle = { top, left };
   } else {
-    cardPlacement = "centered";
+    placement = "centered";
   }
 
-  return (
+  return createPortal(
     <div className="tour-root">
-      {/* Engole cliques no app. Clicar aqui nao fecha: fechar por clique-fora
-          num tour e o jeito classico de perder o usuario sem querer. */}
-      <div className="tour-scrim" aria-hidden="true" />
+      {blocksClicks && <div className="tour-blocker" aria-hidden="true" />}
+
+      {/* Sem ancora nao ha spotlight, entao o escurecimento precisa vir daqui. */}
+      {!rect && !insideStudio && <div className="tour-scrim" aria-hidden="true" />}
 
       {rect && (
-        <div className="tour-spotlight" style={spotlightStyle} aria-hidden="true" />
+        <div className={spotlightClass} style={spotlightStyle} aria-hidden="true" />
       )}
 
       <AnimatePresence mode="wait">
         <motion.div
           key={step.id}
-          className={`tour-card-shell tour-card-${cardPlacement}`}
+          className={`tour-card-shell tour-card-${placement}`}
           style={cardStyle}
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -213,9 +268,7 @@ export const TourOverlay = () => {
               {step.body}
             </Text>
 
-            {step.note && (
-              <p className="tour-note serif-accent">{step.note}</p>
-            )}
+            {step.note && <p className="tour-note serif-accent">{step.note}</p>}
 
             <div className="tour-footer">
               <Button
@@ -239,13 +292,14 @@ export const TourOverlay = () => {
                   </Button>
                 )}
                 <Button variant="soft" className="clickable-control" onClick={next}>
-                  {isLast ? "Concluir" : "Avançar"}
+                  {isLast ? "Concluir" : opensStudio ? "Pular" : "Avançar"}
                 </Button>
               </div>
             </div>
           </Card>
         </motion.div>
       </AnimatePresence>
-    </div>
+    </div>,
+    document.body
   );
 };

--- a/client/src/features/tour/TourProvider.tsx
+++ b/client/src/features/tour/TourProvider.tsx
@@ -1,4 +1,4 @@
-// Estado do tour: em que fase esta e em que passo.
+// Estado do tour: em que fase esta, em que passo, e se o estudio esta aberto.
 //
 // Fica dentro do AppShell, e nao no main.tsx: o AppShell envolve exatamente as
 // paginas autenticadas, e o tour nao deve existir no login nem em /sobre.
@@ -7,11 +7,13 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { readTourRecord, shouldOfferTour, writeTourRecord } from "./tourStorage";
-import { TOUR_STEPS, TourStep } from "./tourSteps";
+import { resolveStepIndex, TOUR_STEPS, TourStep } from "./tourSteps";
 
 type TourPhase = "hidden" | "invite" | "running";
 
@@ -20,25 +22,63 @@ type TourContextValue = {
   step: TourStep | null;
   stepIndex: number;
   stepCount: number;
+  /** O modal do estudio esta aberto agora. */
+  studioOpen: boolean;
   startTour: () => void;
   next: () => void;
   back: () => void;
-  /** Chegou ao fim: grava `done`. */
   finish: () => void;
-  /** Saiu antes do fim, ou recusou o convite: grava `dismissed`. */
   dismiss: () => void;
 };
 
 const TourContext = createContext<TourContextValue | null>(null);
+
+const STUDIO_SELECTOR = '[data-tour-id="studio-dialog"]';
 
 // A leitura do storage acontece uma vez, no primeiro render: se fosse num
 // efeito, o convite piscaria na tela de quem ja dispensou.
 const initialPhase = (): TourPhase =>
   shouldOfferTour(readTourRecord()) ? "invite" : "hidden";
 
+/*
+ * Presenca de um elemento no DOM. O modal do Radix vive num portal fora da
+ * arvore do AppShell, entao observar o `body` e mais simples e mais robusto do
+ * que levantar o estado `open` do ImageStudioDialog ate aqui.
+ */
+const useElementPresence = (selector: string, active: boolean) => {
+  const [present, setPresent] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      setPresent(false);
+      return;
+    }
+
+    const check = () => setPresent(Boolean(document.querySelector(selector)));
+    check();
+
+    const observer = new MutationObserver(check);
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, [selector, active]);
+
+  return present;
+};
+
 export const TourProvider = ({ children }: { children: React.ReactNode }) => {
   const [phase, setPhase] = useState<TourPhase>(initialPhase);
   const [stepIndex, setStepIndex] = useState(0);
+
+  const isRunning = phase === "running";
+  const studioOpen = useElementPresence(STUDIO_SELECTOR, isRunning);
+
+  // Ref porque `next`/`back` sao lidos dentro do updater do setState, onde o
+  // valor capturado pela closure ficaria velho.
+  const studioOpenRef = useRef(studioOpen);
+  studioOpenRef.current = studioOpen;
+
+  const step = isRunning ? TOUR_STEPS[stepIndex] ?? null : null;
 
   const startTour = useCallback(() => {
     setStepIndex(0);
@@ -55,43 +95,78 @@ export const TourProvider = ({ children }: { children: React.ReactNode }) => {
     setPhase("hidden");
   }, []);
 
-  // Avancar do ultimo passo e concluir; nao existe "proximo" que nao leve a
-  // lugar nenhum.
+  /*
+   * O passo de dentro do modal so existe com o modal aberto. Quem clicou
+   * "Avancar" em vez de abrir pula direto para o seguinte, nos dois sentidos —
+   * senao o tour pararia num passo sem ancora e sem contexto.
+   */
+  const resolveIndex = useCallback(
+    (from: number, direction: 1 | -1) =>
+      resolveStepIndex(from, direction, studioOpenRef.current),
+    []
+  );
+
   const next = useCallback(() => {
     setStepIndex((current) => {
-      if (current >= TOUR_STEPS.length - 1) {
+      const target = resolveIndex(current, 1);
+
+      if (target > TOUR_STEPS.length - 1) {
         finish();
         return current;
       }
-      return current + 1;
+
+      return target;
     });
-  }, [finish]);
+  }, [finish, resolveIndex]);
 
   const back = useCallback(() => {
-    setStepIndex((current) => Math.max(0, current - 1));
-  }, []);
+    setStepIndex((current) => Math.max(0, resolveIndex(current, -1)));
+  }, [resolveIndex]);
+
+  // Avanco automatico: o modal abriu no passo que pedia isso, ou fechou no
+  // passo que vivia dentro dele.
+  useEffect(() => {
+    if (!step) return;
+
+    if (step.opensStudio && studioOpen) {
+      setStepIndex((current) => current + 1);
+      return;
+    }
+
+    if (step.insideStudio && !studioOpen) {
+      setStepIndex((current) => {
+        const target = current + 1;
+        if (target > TOUR_STEPS.length - 1) {
+          finish();
+          return current;
+        }
+        return target;
+      });
+    }
+  }, [step, studioOpen, finish]);
 
   const value = useMemo<TourContextValue>(
     () => ({
       phase,
-      step: phase === "running" ? TOUR_STEPS[stepIndex] ?? null : null,
+      step,
       stepIndex,
       stepCount: TOUR_STEPS.length,
+      studioOpen,
       startTour,
       next,
       back,
       finish,
       dismiss,
     }),
-    [phase, stepIndex, startTour, next, back, finish, dismiss]
+    [phase, step, stepIndex, studioOpen, startTour, next, back, finish, dismiss]
   );
 
   return <TourContext.Provider value={value}>{children}</TourContext.Provider>;
 };
 
 /*
- * Devolve `null` fora do provider em vez de lancar: o gatilho "Como funciona"
- * vive no MobileMoreMenu, que tambem e montado na tela de login, onde nao ha
- * TourProvider. Quem consome trata a ausencia escondendo o gatilho.
+ * Devolve `null` fora do provider em vez de lancar: os gatilhos vivem em
+ * componentes que tambem sao montados fora das paginas autenticadas. Quem
+ * consome trata a ausencia escondendo o gatilho.
  */
 export const useTour = () => useContext(TourContext);

--- a/client/src/features/tour/TourProvider.tsx
+++ b/client/src/features/tour/TourProvider.tsx
@@ -1,0 +1,97 @@
+// Estado do tour: em que fase esta e em que passo.
+//
+// Fica dentro do AppShell, e nao no main.tsx: o AppShell envolve exatamente as
+// paginas autenticadas, e o tour nao deve existir no login nem em /sobre.
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import { readTourRecord, shouldOfferTour, writeTourRecord } from "./tourStorage";
+import { TOUR_STEPS, TourStep } from "./tourSteps";
+
+type TourPhase = "hidden" | "invite" | "running";
+
+type TourContextValue = {
+  phase: TourPhase;
+  step: TourStep | null;
+  stepIndex: number;
+  stepCount: number;
+  startTour: () => void;
+  next: () => void;
+  back: () => void;
+  /** Chegou ao fim: grava `done`. */
+  finish: () => void;
+  /** Saiu antes do fim, ou recusou o convite: grava `dismissed`. */
+  dismiss: () => void;
+};
+
+const TourContext = createContext<TourContextValue | null>(null);
+
+// A leitura do storage acontece uma vez, no primeiro render: se fosse num
+// efeito, o convite piscaria na tela de quem ja dispensou.
+const initialPhase = (): TourPhase =>
+  shouldOfferTour(readTourRecord()) ? "invite" : "hidden";
+
+export const TourProvider = ({ children }: { children: React.ReactNode }) => {
+  const [phase, setPhase] = useState<TourPhase>(initialPhase);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  const startTour = useCallback(() => {
+    setStepIndex(0);
+    setPhase("running");
+  }, []);
+
+  const finish = useCallback(() => {
+    writeTourRecord("done");
+    setPhase("hidden");
+  }, []);
+
+  const dismiss = useCallback(() => {
+    writeTourRecord("dismissed");
+    setPhase("hidden");
+  }, []);
+
+  // Avancar do ultimo passo e concluir; nao existe "proximo" que nao leve a
+  // lugar nenhum.
+  const next = useCallback(() => {
+    setStepIndex((current) => {
+      if (current >= TOUR_STEPS.length - 1) {
+        finish();
+        return current;
+      }
+      return current + 1;
+    });
+  }, [finish]);
+
+  const back = useCallback(() => {
+    setStepIndex((current) => Math.max(0, current - 1));
+  }, []);
+
+  const value = useMemo<TourContextValue>(
+    () => ({
+      phase,
+      step: phase === "running" ? TOUR_STEPS[stepIndex] ?? null : null,
+      stepIndex,
+      stepCount: TOUR_STEPS.length,
+      startTour,
+      next,
+      back,
+      finish,
+      dismiss,
+    }),
+    [phase, stepIndex, startTour, next, back, finish, dismiss]
+  );
+
+  return <TourContext.Provider value={value}>{children}</TourContext.Provider>;
+};
+
+/*
+ * Devolve `null` fora do provider em vez de lancar: o gatilho "Como funciona"
+ * vive no MobileMoreMenu, que tambem e montado na tela de login, onde nao ha
+ * TourProvider. Quem consome trata a ausencia escondendo o gatilho.
+ */
+export const useTour = () => useContext(TourContext);

--- a/client/src/features/tour/TourProvider.tsx
+++ b/client/src/features/tour/TourProvider.tsx
@@ -1,4 +1,4 @@
-// Estado do tour: em que fase esta, em que passo, e se o estudio esta aberto.
+// Estado do tour: em que fase esta e em que passo.
 //
 // Fica dentro do AppShell, e nao no main.tsx: o AppShell envolve exatamente as
 // paginas autenticadas, e o tour nao deve existir no login nem em /sobre.
@@ -7,13 +7,11 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { readTourRecord, shouldOfferTour, writeTourRecord } from "./tourStorage";
-import { resolveStepIndex, TOUR_STEPS, TourStep } from "./tourSteps";
+import { TOUR_STEPS, TourStep } from "./tourSteps";
 
 type TourPhase = "hidden" | "invite" | "running";
 
@@ -22,63 +20,25 @@ type TourContextValue = {
   step: TourStep | null;
   stepIndex: number;
   stepCount: number;
-  /** O modal do estudio esta aberto agora. */
-  studioOpen: boolean;
   startTour: () => void;
   next: () => void;
   back: () => void;
+  /** Chegou ao fim: grava `done`. */
   finish: () => void;
+  /** Saiu antes do fim, ou recusou o convite: grava `dismissed`. */
   dismiss: () => void;
 };
 
 const TourContext = createContext<TourContextValue | null>(null);
-
-const STUDIO_SELECTOR = '[data-tour-id="studio-dialog"]';
 
 // A leitura do storage acontece uma vez, no primeiro render: se fosse num
 // efeito, o convite piscaria na tela de quem ja dispensou.
 const initialPhase = (): TourPhase =>
   shouldOfferTour(readTourRecord()) ? "invite" : "hidden";
 
-/*
- * Presenca de um elemento no DOM. O modal do Radix vive num portal fora da
- * arvore do AppShell, entao observar o `body` e mais simples e mais robusto do
- * que levantar o estado `open` do ImageStudioDialog ate aqui.
- */
-const useElementPresence = (selector: string, active: boolean) => {
-  const [present, setPresent] = useState(false);
-
-  useEffect(() => {
-    if (!active) {
-      setPresent(false);
-      return;
-    }
-
-    const check = () => setPresent(Boolean(document.querySelector(selector)));
-    check();
-
-    const observer = new MutationObserver(check);
-    observer.observe(document.body, { childList: true, subtree: true });
-
-    return () => observer.disconnect();
-  }, [selector, active]);
-
-  return present;
-};
-
 export const TourProvider = ({ children }: { children: React.ReactNode }) => {
   const [phase, setPhase] = useState<TourPhase>(initialPhase);
   const [stepIndex, setStepIndex] = useState(0);
-
-  const isRunning = phase === "running";
-  const studioOpen = useElementPresence(STUDIO_SELECTOR, isRunning);
-
-  // Ref porque `next`/`back` sao lidos dentro do updater do setState, onde o
-  // valor capturado pela closure ficaria velho.
-  const studioOpenRef = useRef(studioOpen);
-  studioOpenRef.current = studioOpen;
-
-  const step = isRunning ? TOUR_STEPS[stepIndex] ?? null : null;
 
   const startTour = useCallback(() => {
     setStepIndex(0);
@@ -95,70 +55,35 @@ export const TourProvider = ({ children }: { children: React.ReactNode }) => {
     setPhase("hidden");
   }, []);
 
-  /*
-   * O passo de dentro do modal so existe com o modal aberto. Quem clicou
-   * "Avancar" em vez de abrir pula direto para o seguinte, nos dois sentidos —
-   * senao o tour pararia num passo sem ancora e sem contexto.
-   */
-  const resolveIndex = useCallback(
-    (from: number, direction: 1 | -1) =>
-      resolveStepIndex(from, direction, studioOpenRef.current),
-    []
-  );
-
+  // Avancar do ultimo passo e concluir; nao existe "proximo" que nao leve a
+  // lugar nenhum.
   const next = useCallback(() => {
     setStepIndex((current) => {
-      const target = resolveIndex(current, 1);
-
-      if (target > TOUR_STEPS.length - 1) {
+      if (current >= TOUR_STEPS.length - 1) {
         finish();
         return current;
       }
-
-      return target;
+      return current + 1;
     });
-  }, [finish, resolveIndex]);
+  }, [finish]);
 
   const back = useCallback(() => {
-    setStepIndex((current) => Math.max(0, resolveIndex(current, -1)));
-  }, [resolveIndex]);
-
-  // Avanco automatico: o modal abriu no passo que pedia isso, ou fechou no
-  // passo que vivia dentro dele.
-  useEffect(() => {
-    if (!step) return;
-
-    if (step.opensStudio && studioOpen) {
-      setStepIndex((current) => current + 1);
-      return;
-    }
-
-    if (step.insideStudio && !studioOpen) {
-      setStepIndex((current) => {
-        const target = current + 1;
-        if (target > TOUR_STEPS.length - 1) {
-          finish();
-          return current;
-        }
-        return target;
-      });
-    }
-  }, [step, studioOpen, finish]);
+    setStepIndex((current) => Math.max(0, current - 1));
+  }, []);
 
   const value = useMemo<TourContextValue>(
     () => ({
       phase,
-      step,
+      step: phase === "running" ? TOUR_STEPS[stepIndex] ?? null : null,
       stepIndex,
       stepCount: TOUR_STEPS.length,
-      studioOpen,
       startTour,
       next,
       back,
       finish,
       dismiss,
     }),
-    [phase, step, stepIndex, studioOpen, startTour, next, back, finish, dismiss]
+    [phase, stepIndex, startTour, next, back, finish, dismiss]
   );
 
   return <TourContext.Provider value={value}>{children}</TourContext.Provider>;

--- a/client/src/features/tour/index.ts
+++ b/client/src/features/tour/index.ts
@@ -1,0 +1,4 @@
+export { TourProvider, useTour } from "./TourProvider";
+export { TourOverlay } from "./TourOverlay";
+export { TourInvite } from "./TourInvite";
+export { TourHelpButton } from "./TourHelpButton";

--- a/client/src/features/tour/tour.css
+++ b/client/src/features/tour/tour.css
@@ -2,58 +2,26 @@
  * Estilos do tour.
  *
  * Arquivo proprio e uma quebra consciente do padrao do projeto (estilo
- * concentrado em `index.css`): o tour e autocontido e opcional, e manter ~170
- * linhas dele fora do arquivo de 1500 linhas deixa a feature removivel de uma
- * vez. Precedente: o estudio de imagem ja gera tokens proprios em
- * `studioTheme.ts`.
+ * concentrado em `index.css`): o tour e autocontido e opcional, e deixa-lo fora
+ * do arquivo de 1500 linhas o torna removivel de uma vez.
  *
- * Empilhamento: o overlay e portalizado no `body` e usa 9000+. Precisa passar do
- * modal do Radix, cujo overlay nao declara z-index (fica em `auto`) e ganharia
- * so por ordem de DOM. Fica abaixo do grao global (9999), que nao intercepta
- * clique.
+ * Empilhamento dentro de `.app-background` (que e um contexto proprio, por causa
+ * do `isolation: isolate`): header 40, tab bar 45, tour 60-62.
  */
-
-/*
- * Raiz do portal. Precisa ser um `<Theme>` do Radix, e nao uma div qualquer:
- * TODOS os tokens (--color-panel-solid, --sand-*, --accent-*, --space-*) sao
- * escopados em `:where(.radix-themes)`. Portalizado no body sem isso, o card
- * ficava sem fundo e o spotlight sem escurecimento — a "UI transparente".
- *
- * `pointer-events: none` aqui, `auto` em cada camada interativa: o Radix Dialog
- * usa react-remove-scroll, que poe `pointer-events: none` no body enquanto o
- * modal esta aberto. Como o tour e filho do body, ele herdava isso e nada
- * respondia a clique.
- *
- * `position: fixed` + z-index cria o contexto de empilhamento do tour inteiro
- * acima do modal, que nao declara z-index proprio.
- */
-.tour-theme {
-  position: fixed;
-  inset: 0;
-  z-index: 9000;
-  pointer-events: none;
-  background: none;
-}
-
-.tour-blocker,
-.tour-scrim,
-.tour-card-shell {
-  pointer-events: auto;
-}
 
 /* Invisivel: existe so para engolir cliques no app durante os passos passivos.
    Nao escurece nada — quem escurece e a sombra do spotlight. */
 .tour-blocker {
   position: fixed;
   inset: 0;
-  z-index: 1;
+  z-index: 60;
 }
 
 /* Usado apenas quando nao ha ancora e, portanto, nao ha spotlight. */
 .tour-scrim {
   position: fixed;
   inset: 0;
-  z-index: 1;
+  z-index: 60;
   background: color-mix(in srgb, var(--sand-1) 78%, transparent);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
@@ -70,7 +38,7 @@
  */
 .tour-spotlight {
   position: fixed;
-  z-index: 2;
+  z-index: 61;
   border-radius: var(--radius-4);
   box-shadow:
     0 0 0 9999px color-mix(in srgb, var(--sand-1) 78%, transparent),
@@ -84,17 +52,9 @@
     height 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-/* Dentro do estudio quem escurece e o overlay do proprio modal; aqui sobra so
-   o anel, senao o modal levaria duas camadas de escuro. */
-.tour-spotlight-ring {
-  box-shadow:
-    0 0 0 2px var(--accent-8),
-    0 0 44px -8px var(--accent-a6);
-}
-
 .tour-card-shell {
   position: fixed;
-  z-index: 3;
+  z-index: 62;
   width: min(24rem, calc(100vw - 2rem));
 }
 

--- a/client/src/features/tour/tour.css
+++ b/client/src/features/tour/tour.css
@@ -13,19 +13,47 @@
  * clique.
  */
 
+/*
+ * Raiz do portal. Precisa ser um `<Theme>` do Radix, e nao uma div qualquer:
+ * TODOS os tokens (--color-panel-solid, --sand-*, --accent-*, --space-*) sao
+ * escopados em `:where(.radix-themes)`. Portalizado no body sem isso, o card
+ * ficava sem fundo e o spotlight sem escurecimento — a "UI transparente".
+ *
+ * `pointer-events: none` aqui, `auto` em cada camada interativa: o Radix Dialog
+ * usa react-remove-scroll, que poe `pointer-events: none` no body enquanto o
+ * modal esta aberto. Como o tour e filho do body, ele herdava isso e nada
+ * respondia a clique.
+ *
+ * `position: fixed` + z-index cria o contexto de empilhamento do tour inteiro
+ * acima do modal, que nao declara z-index proprio.
+ */
+.tour-theme {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  pointer-events: none;
+  background: none;
+}
+
+.tour-blocker,
+.tour-scrim,
+.tour-card-shell {
+  pointer-events: auto;
+}
+
 /* Invisivel: existe so para engolir cliques no app durante os passos passivos.
    Nao escurece nada — quem escurece e a sombra do spotlight. */
 .tour-blocker {
   position: fixed;
   inset: 0;
-  z-index: 9000;
+  z-index: 1;
 }
 
 /* Usado apenas quando nao ha ancora e, portanto, nao ha spotlight. */
 .tour-scrim {
   position: fixed;
   inset: 0;
-  z-index: 9000;
+  z-index: 1;
   background: color-mix(in srgb, var(--sand-1) 78%, transparent);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
@@ -42,7 +70,7 @@
  */
 .tour-spotlight {
   position: fixed;
-  z-index: 9001;
+  z-index: 2;
   border-radius: var(--radius-4);
   box-shadow:
     0 0 0 9999px color-mix(in srgb, var(--sand-1) 78%, transparent),
@@ -66,7 +94,7 @@
 
 .tour-card-shell {
   position: fixed;
-  z-index: 9002;
+  z-index: 3;
   width: min(24rem, calc(100vw - 2rem));
 }
 

--- a/client/src/features/tour/tour.css
+++ b/client/src/features/tour/tour.css
@@ -1,0 +1,183 @@
+/*
+ * Estilos do tour.
+ *
+ * Arquivo proprio e uma quebra consciente do padrao do projeto (estilo
+ * concentrado em `index.css`): o tour e autocontido e opcional, e manter ~150
+ * linhas dele fora do arquivo de 1500 linhas evita conflito e deixa a feature
+ * removivel de uma vez. Precedente: o estudio de imagem ja gera tokens proprios
+ * em `studioTheme.ts`.
+ *
+ * Empilhamento: header 40, tab bar 45, scrim 60, spotlight 61, card 62.
+ */
+
+.tour-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: color-mix(in srgb, var(--sand-1) 78%, transparent);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+
+/*
+ * O spotlight nao usa mascara SVG nem quatro divs: uma sombra de 9999px pinta a
+ * tela toda menos este retangulo, e o proprio `border-radius` recorta o buraco.
+ *
+ * O anel em `--accent-8` e o mesmo token do `:focus-visible` global — e o que
+ * faz o recorte ler como parte do app, e nao como overlay de plugin.
+ */
+.tour-spotlight {
+  position: fixed;
+  z-index: 61;
+  border-radius: var(--radius-4);
+  box-shadow:
+    0 0 0 9999px color-mix(in srgb, var(--sand-1) 78%, transparent),
+    0 0 0 2px var(--accent-8),
+    0 0 44px -8px var(--accent-a6);
+  pointer-events: none;
+  transition:
+    top 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    left 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    width 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    height 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tour-card-shell {
+  position: fixed;
+  z-index: 62;
+  width: min(24rem, calc(100vw - 2rem));
+}
+
+.tour-card-centered {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/*
+ * No mobile o card nao flutua: vira folha ancorada numa borda, largura total.
+ * A de baixo para acima da barra de navegacao; a de cima e usada quando o
+ * proprio alvo esta na metade inferior, senao a folha cobriria o alvo.
+ */
+.tour-card-sheet-bottom,
+.tour-card-sheet-top {
+  right: var(--space-3);
+  left: var(--space-3);
+  width: auto;
+}
+
+.tour-card-sheet-bottom {
+  bottom: calc(5.4rem + env(safe-area-inset-bottom));
+}
+
+.tour-card-sheet-top {
+  top: calc(4.5rem + env(safe-area-inset-top));
+}
+
+/*
+ * Mais opaco que o `.hero-panel`: o card fica sobre o scrim escurecido, e vidro
+ * fosco em cima de vidro fosco derruba a legibilidade do texto. O vidro fica no
+ * scrim e no anel do spotlight, nao aqui.
+ */
+.tour-card {
+  background: var(--color-panel-solid);
+  border: 1px solid var(--sand-a6);
+  box-shadow:
+    0 28px 60px -30px var(--sand-a12),
+    inset 0 1px 0 color-mix(in srgb, #fff 14%, transparent);
+  outline: none;
+}
+
+/* Numeracao de tracklist, nao fileira de bolinhas. */
+.tour-progress {
+  display: flex;
+  gap: 0.55rem;
+  margin: 0 0 var(--space-3);
+  font-family: "Fraunces", serif;
+  font-size: 0.7rem;
+  font-variation-settings: "opsz" 90, "WONK" 1;
+  letter-spacing: 0.06em;
+  color: var(--gray-9);
+}
+
+.tour-progress-current {
+  color: var(--accent-11);
+}
+
+.tour-title {
+  margin-bottom: var(--space-2);
+}
+
+.tour-body {
+  line-height: 1.65;
+}
+
+/*
+ * A "letra miuda" do encarte: a ressalva honesta sobre o dado, em Fraunces
+ * italico, atras de um filete na cor do acento.
+ */
+.tour-note {
+  margin: var(--space-3) 0 0;
+  padding-left: var(--space-3);
+  border-left: 2px solid var(--accent-a7);
+  color: var(--gray-11);
+  font-size: var(--font-size-1);
+  line-height: 1.6;
+}
+
+.tour-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.tour-footer-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.tour-exit {
+  margin-right: auto;
+}
+
+/* Alvos de toque no mobile; sem `:hover`, o `:active` e o unico retorno. */
+@media (max-width: 820px) {
+  .tour-footer .rt-Button {
+    --base-button-height: 2.75rem;
+    padding-inline: var(--space-3);
+  }
+
+  .tour-card .rt-Button:active {
+    transform: scale(0.96);
+  }
+}
+
+/* ---------- Convite ---------- */
+
+.tour-invite-body {
+  margin-top: var(--space-1);
+  line-height: 1.6;
+  max-width: 42rem;
+}
+
+.tour-invite-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+@media (max-width: 820px) {
+  /* Recusar tem que ser tao facil quanto aceitar: mesma altura, mesma linha. */
+  .tour-invite-actions .rt-Button {
+    --base-button-height: 2.75rem;
+    flex: 1 1 auto;
+  }
+
+  .tour-invite-actions .rt-Button:active {
+    transform: scale(0.96);
+  }
+}

--- a/client/src/features/tour/tour.css
+++ b/client/src/features/tour/tour.css
@@ -2,18 +2,30 @@
  * Estilos do tour.
  *
  * Arquivo proprio e uma quebra consciente do padrao do projeto (estilo
- * concentrado em `index.css`): o tour e autocontido e opcional, e manter ~150
- * linhas dele fora do arquivo de 1500 linhas evita conflito e deixa a feature
- * removivel de uma vez. Precedente: o estudio de imagem ja gera tokens proprios
- * em `studioTheme.ts`.
+ * concentrado em `index.css`): o tour e autocontido e opcional, e manter ~170
+ * linhas dele fora do arquivo de 1500 linhas deixa a feature removivel de uma
+ * vez. Precedente: o estudio de imagem ja gera tokens proprios em
+ * `studioTheme.ts`.
  *
- * Empilhamento: header 40, tab bar 45, scrim 60, spotlight 61, card 62.
+ * Empilhamento: o overlay e portalizado no `body` e usa 9000+. Precisa passar do
+ * modal do Radix, cujo overlay nao declara z-index (fica em `auto`) e ganharia
+ * so por ordem de DOM. Fica abaixo do grao global (9999), que nao intercepta
+ * clique.
  */
 
+/* Invisivel: existe so para engolir cliques no app durante os passos passivos.
+   Nao escurece nada — quem escurece e a sombra do spotlight. */
+.tour-blocker {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+}
+
+/* Usado apenas quando nao ha ancora e, portanto, nao ha spotlight. */
 .tour-scrim {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: 9000;
   background: color-mix(in srgb, var(--sand-1) 78%, transparent);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
@@ -22,13 +34,15 @@
 /*
  * O spotlight nao usa mascara SVG nem quatro divs: uma sombra de 9999px pinta a
  * tela toda menos este retangulo, e o proprio `border-radius` recorta o buraco.
+ * Por isso nao pode haver um scrim junto — ele cobriria o buraco e o alvo
+ * destacado ficaria escuro tambem.
  *
- * O anel em `--accent-8` e o mesmo token do `:focus-visible` global — e o que
- * faz o recorte ler como parte do app, e nao como overlay de plugin.
+ * O anel em `--accent-8` e o mesmo token do `:focus-visible` global: e o que faz
+ * o recorte ler como parte do app, e nao como overlay de plugin.
  */
 .tour-spotlight {
   position: fixed;
-  z-index: 61;
+  z-index: 9001;
   border-radius: var(--radius-4);
   box-shadow:
     0 0 0 9999px color-mix(in srgb, var(--sand-1) 78%, transparent),
@@ -42,9 +56,17 @@
     height 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/* Dentro do estudio quem escurece e o overlay do proprio modal; aqui sobra so
+   o anel, senao o modal levaria duas camadas de escuro. */
+.tour-spotlight-ring {
+  box-shadow:
+    0 0 0 2px var(--accent-8),
+    0 0 44px -8px var(--accent-a6);
+}
+
 .tour-card-shell {
   position: fixed;
-  z-index: 62;
+  z-index: 9002;
   width: min(24rem, calc(100vw - 2rem));
 }
 
@@ -55,15 +77,17 @@
 }
 
 /*
- * No mobile o card nao flutua: vira folha ancorada numa borda, largura total.
- * A de baixo para acima da barra de navegacao; a de cima e usada quando o
- * proprio alvo esta na metade inferior, senao a folha cobriria o alvo.
+ * Folha ancorada numa borda, largura total. A de baixo fica acima da barra de
+ * navegacao; a de cima entra quando o proprio alvo esta na metade inferior,
+ * senao a folha cobriria o alvo.
  */
 .tour-card-sheet-bottom,
 .tour-card-sheet-top {
   right: var(--space-3);
   left: var(--space-3);
   width: auto;
+  max-width: 34rem;
+  margin-inline: auto;
 }
 
 .tour-card-sheet-bottom {
@@ -75,9 +99,8 @@
 }
 
 /*
- * Mais opaco que o `.hero-panel`: o card fica sobre o scrim escurecido, e vidro
- * fosco em cima de vidro fosco derruba a legibilidade do texto. O vidro fica no
- * scrim e no anel do spotlight, nao aqui.
+ * Mais opaco que o `.hero-panel`: o card fica sobre area escurecida, e vidro
+ * fosco em cima de vidro fosco derruba a legibilidade do texto.
  */
 .tour-card {
   background: var(--color-panel-solid);

--- a/client/src/features/tour/tourSteps.ts
+++ b/client/src/features/tour/tourSteps.ts
@@ -1,8 +1,9 @@
 // Conteudo do tour: so dados e texto, sem JSX e sem DOM.
 //
-// Os dois primeiros passos sao interativos: o tour pede para abrir o estudio de
-// imagem e so avanca quando o modal abre de fato. Os quatro seguintes rodam na
-// home, na ordem de leitura da propria pagina.
+// Todos os passos apontam para algo que ja esta na home. O tour nao abre nem
+// controla o modal do estudio de imagem: overlay convivendo com overlay
+// significa disputar foco, `pointer-events` e contexto de empilhamento com o
+// Dialog do Radix, e nao vale o risco por um passo.
 
 export type TourStep = {
   id: string;
@@ -12,14 +13,6 @@ export type TourStep = {
   note?: string;
   /** Seletores em ordem de prioridade; vence o primeiro que estiver visivel. */
   anchors: string[];
-  /**
-   * O passo espera o usuario abrir o estudio. O tour nao bloqueia cliques aqui,
-   * avanca sozinho quando o modal aparece, e "Avancar" pula o passo de dentro
-   * do modal (que nao teria ancora).
-   */
-  opensStudio?: boolean;
-  /** O passo vive dentro do modal; sai sozinho quando o modal fecha. */
-  insideStudio?: boolean;
 };
 
 /*
@@ -31,18 +24,10 @@ export const TOUR_VERSION = 1;
 
 export const TOUR_STEPS: TourStep[] = [
   {
-    id: "studio-open",
+    id: "studio",
     title: "Uma imagem com os seus stats",
-    body: "Esse botão monta uma imagem pronta pra baixar a partir do que você mais ouve. Abre ele pra ver os dois formatos.",
+    body: "Esse botão monta um pôster do seu ranking de artistas ou faixas, ou um mosaico de capas — com período e cor à sua escolha, pra baixar em PNG ou JPG.",
     anchors: [".profile-action"],
-    opensStudio: true,
-  },
-  {
-    id: "studio-formats",
-    title: "Pôster ou mosaico",
-    body: "O pôster lista o seu ranking de artistas ou de faixas. O mosaico monta uma grade de capas de álbum ou de fotos de artista. Nos dois dá pra escolher o período e a cor, e exportar em PNG ou JPG.",
-    anchors: ['[data-tour-id="studio-formats"]'],
-    insideStudio: true,
   },
   {
     id: "rankings",
@@ -71,26 +56,3 @@ export const TOUR_STEPS: TourStep[] = [
     anchors: [".mobile-tab-more", ".utility-actions"],
   },
 ];
-
-/**
- * Proximo indice na direcao dada, pulando os passos que so existem com o modal
- * do estudio aberto. Funcao pura para poder ser testada sem DOM.
- */
-export const resolveStepIndex = (
-  from: number,
-  direction: 1 | -1,
-  studioOpen: boolean
-): number => {
-  let target = from + direction;
-
-  while (
-    target >= 0 &&
-    target < TOUR_STEPS.length &&
-    TOUR_STEPS[target].insideStudio &&
-    !studioOpen
-  ) {
-    target += direction;
-  }
-
-  return target;
-};

--- a/client/src/features/tour/tourSteps.ts
+++ b/client/src/features/tour/tourSteps.ts
@@ -1,0 +1,56 @@
+// Conteudo do tour: so dados e texto, sem JSX e sem DOM.
+//
+// Todos os passos ficam na home, na ordem de leitura da propria pagina: quem
+// voce e, seus rankings, como ler os numeros, para onde ir, como ajustar.
+
+export type TourStep = {
+  id: string;
+  title: string;
+  body: string;
+  /** Ressalva honesta sobre o dado, em Fraunces italico — a "letra miuda" do encarte. */
+  note?: string;
+  /** Seletores em ordem de prioridade; vence o primeiro que estiver visivel. */
+  anchors: string[];
+};
+
+/*
+ * Incrementar SOMENTE quando entrar passo novo, nunca por ajuste de texto —
+ * senao isto vira contador de deploy e reconvida quem ja concluiu a cada
+ * correcao de virgula.
+ */
+export const TOUR_VERSION = 1;
+
+export const TOUR_STEPS: TourStep[] = [
+  {
+    id: "profile",
+    title: "Seu cartão e a imagem pra baixar",
+    body: "Seus números de conta ficam aqui: seguidores, playlists e artistas que você segue. O botão \"Gerar imagem\" monta um pôster do seu ranking ou um mosaico de capas, pra baixar.",
+    anchors: [".profile-card"],
+  },
+  {
+    id: "rankings",
+    title: "Top artistas e top faixas",
+    body: "Os dois rankings vêm prontos do Spotify — o app não recalcula nada. Abrindo cada um dá pra trocar o período: últimas 4 semanas, últimos 6 meses ou o último ano.",
+    note: "Os períodos são aproximados; quem define o corte é o Spotify. E \"top álbuns\" não existe: a API só devolve top de artistas e de faixas.",
+    anchors: ['[data-tour-id="rankings"]'],
+  },
+  {
+    id: "popularity",
+    title: "Popularidade é um número de catálogo",
+    body: "Vai de 0 a 100 e é calculado pelo Spotify a partir do total de reproduções da faixa e de quão recentes elas são — de todo mundo, não das suas. Não mede qualidade: um clássico com bilhões de plays antigos pode pontuar abaixo de um lançamento em alta. A mesma música em single e em álbum recebe notas separadas, e a nota do artista sai da popularidade das faixas dele.",
+    note: "Os gêneros embaixo do nome são a classificação do próprio Spotify, feita por artista e não por faixa — por isso às vezes destoam do que a pessoa lança hoje.",
+    anchors: ['[data-tour-id="popularity"]', '[data-tour-id="ranking-row"]'],
+  },
+  {
+    id: "navigation",
+    title: "Busca e biblioteca",
+    body: "A busca varre o catálogo inteiro do Spotify — músicas, artistas e álbuns. A biblioteca mostra o que você salvou: músicas curtidas, álbuns e os artistas que segue.",
+    anchors: [".mobile-tabbar", ".nav-actions"],
+  },
+  {
+    id: "appearance",
+    title: "Cor, tema e o que o app não faz",
+    body: "Dá pra alternar entre claro e escuro e escolher a cor de destaque; a escolha fica salva neste navegador. Em \"Sobre\" está o resto: o login acontece no Spotify, o app só lê os seus dados e não guarda nada.",
+    anchors: [".mobile-tab-more", ".utility-actions"],
+  },
+];

--- a/client/src/features/tour/tourSteps.ts
+++ b/client/src/features/tour/tourSteps.ts
@@ -1,7 +1,8 @@
 // Conteudo do tour: so dados e texto, sem JSX e sem DOM.
 //
-// Todos os passos ficam na home, na ordem de leitura da propria pagina: quem
-// voce e, seus rankings, como ler os numeros, para onde ir, como ajustar.
+// Os dois primeiros passos sao interativos: o tour pede para abrir o estudio de
+// imagem e so avanca quando o modal abre de fato. Os quatro seguintes rodam na
+// home, na ordem de leitura da propria pagina.
 
 export type TourStep = {
   id: string;
@@ -11,6 +12,14 @@ export type TourStep = {
   note?: string;
   /** Seletores em ordem de prioridade; vence o primeiro que estiver visivel. */
   anchors: string[];
+  /**
+   * O passo espera o usuario abrir o estudio. O tour nao bloqueia cliques aqui,
+   * avanca sozinho quando o modal aparece, e "Avancar" pula o passo de dentro
+   * do modal (que nao teria ancora).
+   */
+  opensStudio?: boolean;
+  /** O passo vive dentro do modal; sai sozinho quando o modal fecha. */
+  insideStudio?: boolean;
 };
 
 /*
@@ -22,10 +31,18 @@ export const TOUR_VERSION = 1;
 
 export const TOUR_STEPS: TourStep[] = [
   {
-    id: "profile",
-    title: "Seu cartão e a imagem pra baixar",
-    body: "Seus números de conta ficam aqui: seguidores, playlists e artistas que você segue. O botão \"Gerar imagem\" monta um pôster do seu ranking ou um mosaico de capas, pra baixar.",
-    anchors: [".profile-card"],
+    id: "studio-open",
+    title: "Uma imagem com os seus stats",
+    body: "Esse botão monta uma imagem pronta pra baixar a partir do que você mais ouve. Abre ele pra ver os dois formatos.",
+    anchors: [".profile-action"],
+    opensStudio: true,
+  },
+  {
+    id: "studio-formats",
+    title: "Pôster ou mosaico",
+    body: "O pôster lista o seu ranking de artistas ou de faixas. O mosaico monta uma grade de capas de álbum ou de fotos de artista. Nos dois dá pra escolher o período e a cor, e exportar em PNG ou JPG.",
+    anchors: ['[data-tour-id="studio-formats"]'],
+    insideStudio: true,
   },
   {
     id: "rankings",
@@ -37,20 +54,43 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: "popularity",
     title: "Popularidade é um número de catálogo",
-    body: "Vai de 0 a 100 e é calculado pelo Spotify a partir do total de reproduções da faixa e de quão recentes elas são — de todo mundo, não das suas. Não mede qualidade: um clássico com bilhões de plays antigos pode pontuar abaixo de um lançamento em alta. A mesma música em single e em álbum recebe notas separadas, e a nota do artista sai da popularidade das faixas dele.",
+    body: "Vai de 0 a 100 e é calculado pelo Spotify a partir do total de reproduções da faixa e de quão recentes elas são — de todo mundo, não das suas. Não mede qualidade: um clássico com bilhões de plays antigos pode pontuar abaixo de um lançamento em alta.",
     note: "Os gêneros embaixo do nome são a classificação do próprio Spotify, feita por artista e não por faixa — por isso às vezes destoam do que a pessoa lança hoje.",
     anchors: ['[data-tour-id="popularity"]', '[data-tour-id="ranking-row"]'],
   },
   {
     id: "navigation",
     title: "Busca e biblioteca",
-    body: "A busca varre o catálogo inteiro do Spotify — músicas, artistas e álbuns. A biblioteca mostra o que você salvou: músicas curtidas, álbuns e os artistas que segue.",
+    body: "A busca varre o catálogo inteiro do Spotify. A biblioteca mostra o que você salvou: músicas curtidas, álbuns e os artistas que segue.",
     anchors: [".mobile-tabbar", ".nav-actions"],
   },
   {
     id: "appearance",
-    title: "Cor, tema e o que o app não faz",
-    body: "Dá pra alternar entre claro e escuro e escolher a cor de destaque; a escolha fica salva neste navegador. Em \"Sobre\" está o resto: o login acontece no Spotify, o app só lê os seus dados e não guarda nada.",
+    title: "Cor e tema",
+    body: "Dá pra alternar entre claro e escuro e escolher a cor de destaque. A escolha fica salva neste navegador.",
     anchors: [".mobile-tab-more", ".utility-actions"],
   },
 ];
+
+/**
+ * Proximo indice na direcao dada, pulando os passos que so existem com o modal
+ * do estudio aberto. Funcao pura para poder ser testada sem DOM.
+ */
+export const resolveStepIndex = (
+  from: number,
+  direction: 1 | -1,
+  studioOpen: boolean
+): number => {
+  let target = from + direction;
+
+  while (
+    target >= 0 &&
+    target < TOUR_STEPS.length &&
+    TOUR_STEPS[target].insideStudio &&
+    !studioOpen
+  ) {
+    target += direction;
+  }
+
+  return target;
+};

--- a/client/src/features/tour/tourStorage.ts
+++ b/client/src/features/tour/tourStorage.ts
@@ -1,0 +1,79 @@
+// Persistencia do tour numa chave so, no padrao `sonarstats_*` ja usado pelo
+// tema e pelo estudio de imagem.
+//
+// JSON em vez de tres booleanos: uma leitura, uma escrita, e evoluir o formato
+// depois nao exige migracao. Nao ha chave legada — o tour e feature nova.
+
+import { TOUR_VERSION } from "./tourSteps";
+
+const TOUR_KEY = "sonarstats_tour";
+
+export type TourStatus = "done" | "dismissed";
+
+export type TourRecord = {
+  /** Versao do conteudo do tour quando ele foi resolvido. */
+  v: number;
+  status: TourStatus;
+  /** Nao alimenta nenhuma regra hoje; existe para debug e para evitar migracao. */
+  at: string;
+};
+
+const isTourRecord = (value: unknown): value is TourRecord => {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+
+  return (
+    typeof record.v === "number" &&
+    (record.status === "done" || record.status === "dismissed")
+  );
+};
+
+/*
+ * Leitura defensiva: localStorage pode lancar (Safari privado, storage cheio) e
+ * o valor pode ter sido editado a mao. Qualquer coisa fora do formato e tratada
+ * como "nunca viu o tour" — o custo de errar para esse lado e um convite a mais,
+ * nao uma tela quebrada.
+ */
+export const readTourRecord = (): TourRecord | null => {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem(TOUR_KEY);
+    if (!raw) return null;
+
+    const parsed: unknown = JSON.parse(raw);
+    return isTourRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+export const writeTourRecord = (status: TourStatus) => {
+  if (typeof window === "undefined") return;
+
+  try {
+    const record: TourRecord = {
+      v: TOUR_VERSION,
+      status,
+      at: new Date().toISOString(),
+    };
+    window.localStorage.setItem(TOUR_KEY, JSON.stringify(record));
+  } catch {
+    // Sem storage o tour volta a ser oferecido na proxima visita. E aceitavel:
+    // a alternativa seria quebrar a home por causa de um convite.
+  }
+};
+
+/*
+ * Quem dispensou nao e reconvidado, nem por versao nova: reaparecer para quem
+ * disse "agora nao" e exatamente a sugestao que o requisito proibe. O caminho de
+ * volta e permanente e explicito — "Como funciona", no menu.
+ *
+ * Quem concluiu volta a ser convidado quando entram passos novos.
+ */
+export const shouldOfferTour = (record: TourRecord | null): boolean => {
+  if (!record) return true;
+  if (record.status === "dismissed") return false;
+
+  return record.v < TOUR_VERSION;
+};

--- a/client/src/features/tour/useAnchorRect.ts
+++ b/client/src/features/tour/useAnchorRect.ts
@@ -1,0 +1,85 @@
+// Resolve o alvo de um passo e acompanha o retangulo dele.
+//
+// `querySelector` sozinho nao serve: os dois conjuntos de navegacao existem
+// sempre no DOM e sao escondidos por media query (`.nav-actions` some abaixo de
+// 820px, `.mobile-tabbar` some acima). O criterio precisa ser visibilidade
+// computada — assim o mesmo passo aponta para a tab bar no mobile e para o
+// header no desktop, sem nenhum branch de layout.
+
+import { useEffect, useState } from "react";
+
+const isVisible = (element: HTMLElement) => {
+  if (typeof element.checkVisibility === "function") {
+    return element.checkVisibility();
+  }
+
+  const rect = element.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+};
+
+/** Primeiro seletor da lista que resolve para um elemento visivel. */
+export const resolveAnchor = (selectors: string[]): HTMLElement | null => {
+  for (const selector of selectors) {
+    const element = document.querySelector<HTMLElement>(selector);
+    if (element && isVisible(element)) return element;
+  }
+
+  return null;
+};
+
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/**
+ * `null` quando nao ha passo ativo ou quando nenhum seletor resolveu — nesse
+ * caso o card do tour cai no modo centrado, sem spotlight.
+ */
+export const useAnchorRect = (selectors: string[] | null): DOMRect | null => {
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const key = selectors?.join("|") ?? "";
+
+  useEffect(() => {
+    if (!selectors) {
+      setRect(null);
+      return;
+    }
+
+    const target = resolveAnchor(selectors);
+    if (!target) {
+      setRect(null);
+      return;
+    }
+
+    const measure = () => setRect(target.getBoundingClientRect());
+
+    // Traz o alvo para a tela antes de medir. `behavior` e JS, entao a regra
+    // global de prefers-reduced-motion no CSS nao alcanca isto.
+    target.scrollIntoView({
+      behavior: prefersReducedMotion() ? "auto" : "smooth",
+      block: "center",
+      inline: "nearest",
+    });
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(target);
+
+    // `capture` porque o scroll pode acontecer num container interno, e o evento
+    // de scroll nao borbulha.
+    window.addEventListener("scroll", measure, { passive: true, capture: true });
+    window.addEventListener("resize", measure);
+    window.visualViewport?.addEventListener("resize", measure);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("scroll", measure, true);
+      window.removeEventListener("resize", measure);
+      window.visualViewport?.removeEventListener("resize", measure);
+    };
+    // `key` cobre a mudanca de passo; `selectors` e constante de modulo.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return rect;
+};

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -3,11 +3,13 @@ import { PlaylistOverview } from "../components/Playlist/PlaylistOverview";
 import { Profile } from "../components/Profile/Profile";
 import { TopRankingsOverview } from "../components/Ranking/TopRankingsOverview";
 import { RecentlyPlayedTracks } from "../components/Track/RecentlyPlayedTracks";
+import { TourInvite } from "../features/tour";
 
 export const Home = () => {
   return (
     <AppShell>
       <Profile />
+      <TourInvite />
       <TopRankingsOverview />
       <PlaylistOverview />
       <RecentlyPlayedTracks />


### PR DESCRIPTION
Guia de onboarding para quem entra pela primeira vez. Cinco passos, todos na
home, sem mudanca de rota e sem dependencia nova.

## Os passos

```
01 studio       -> .profile-action           botao Gerar imagem
02 rankings     -> [data-tour-id="rankings"]
03 popularity   -> popularidade / primeira linha do ranking
04 navigation   -> tab bar (mobile) | nav do header (desktop)
05 appearance   -> menu Mais | utilitarios do header
```

O passo 3 e de proposito o mais longo: e o unico cujo conteudo e o motivo do
tour existir. Os outros quatro sao localizacao.

## Os tres requisitos

**Nao invasivo.** O tour nunca comeca sozinho. O convite e uma faixa no fluxo da
home, entre o card de perfil e os rankings — nao modal, nao toast, nao ponto
pulsante. Nao sobrepoe nada, rola junto e some ao ser respondido. Recusar custa o
mesmo que aceitar: dois botoes de texto, nao um X de 16px. So aparece depois que
o perfil resolveu, senao apareceria sobre skeletons.

**Nao bugado.** Estado em `sonarstats_tour`, JSON `{v, status, at}`. Quem
dispensou **nunca mais** e reconvidado — nem por versao nova. Quem concluiu volta
a ser convidado quando entram passos novos, e `TOUR_VERSION` so sobe quando ha
passo novo, nunca por ajuste de texto.

O "nunca mais" so e defensavel por causa das **duas portas permanentes**: botao
de ajuda no header (desktop) e "Como funciona" no menu Mais (mobile).

**No tom do design.** Titulo em Fraunces, e a ressalva sobre cada dado numa nota
em Fraunces italico atras de um filete na cor do acento — a letra miuda do
encarte. Progresso como numeracao de tracklist (`01 · 02 · 03`), nao bolinhas. O
anel do spotlight usa `--accent-8`, o mesmo token do `:focus-visible` global.

## A parte dificil: ancorar nos dois layouts

`querySelector` nao serve. Os dois conjuntos de navegacao **existem sempre no
DOM** e sao escondidos por media query: `.nav-actions` some abaixo de 820px,
`.mobile-tabbar` some acima. O resolvedor usa `Element.checkVisibility()` com
fallback por retangulo, entao o mesmo passo aponta para a tab bar no mobile e
para o header no desktop, sem branch de layout.

Todo passo tem fallback centrado sem ancora, e **nenhum texto usa dexis** ("o
botao ao lado"), porque o que esta visivel muda com a largura.

## Sem biblioteca

`react-joyride`, `driver.js`, `intro.js` e `@reactour` foram avaliados: todas
trazem CSS proprio que teria de ser sobrescrito para casar com os tokens
`--accent-*` e Fraunces, e nenhuma resolve o alvo escondido em outro breakpoint.

O spotlight e um elemento so com `box-shadow: 0 0 0 9999px`, que pinta a tela
menos o retangulo. O bloqueio de clique e uma camada transparente separada — se
o escurecimento viesse de um scrim por cima, ele cobriria o proprio buraco e o
alvo destacado ficaria escuro tambem.

## O que ficou de fora, e por que

Uma versao anterior deste PR fazia o tour abrir o modal do estudio de imagem e
descrever poster e mosaico la dentro. Foi removida.

Overlay convivendo com overlay significa disputar tres coisas com o Dialog do
Radix, e as tres quebraram: os tokens do tema (escopados em `.radix-themes`, e o
portal no body saia desse escopo), o `pointer-events: none` que o
`react-remove-scroll` poe no body enquanto o modal esta aberto, e o focus trap.

Sem esse passo, o overlay volta para dentro da arvore do AppShell e nenhum dos
tres problemas existe. Sobra um passo passivo apontando o botao.

## Verificacao

- `npm run build` passa.
- Persistencia testada nos cinco casos: sem registro, dispensou, dispensou em
  versao antiga, concluiu, concluiu em versao antiga.
- Ancoras conferidas no fonte e no bundle; ids unicos; todo passo tem ancora.
- `Login` e `/sobre` nao usam `AppShell`, entao nao ha tour la.

## Nao verificado

**Nada foi visto renderizado** — sem browser no ambiente. O recorte do spotlight
e o posicionamento do card (folha no mobile, flutuante no desktop, centrado
quando a ancora e maior que a viewport) foram derivados por aritmetica.