### PR TITLE
fix(share): rotulo honesto no compartilhar e aviso de navegador embutido

### DIFF
--- a/client/src/features/auth/InAppBrowserNotice.tsx
+++ b/client/src/features/auth/InAppBrowserNotice.tsx
@@ -1,0 +1,23 @@
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+import { Callout } from "@radix-ui/themes";
+import { isInAppBrowser } from "./inAppBrowser";
+
+// Aviso para quem abriu o app de dentro de outro app (Instagram, Facebook...).
+// Nesses navegadores embutidos o login do Spotify quase sempre falha ou exige
+// digitar a senha, porque eles nao compartilham a sessao com o navegador.
+export const InAppBrowserNotice = () => {
+  if (!isInAppBrowser()) return null;
+
+  return (
+    <Callout.Root color="amber" size="1" mb="4" role="status">
+      <Callout.Icon>
+        <ExclamationTriangleIcon />
+      </Callout.Icon>
+      <Callout.Text>
+        Você abriu por dentro de outro app. O login do Spotify costuma falhar
+        aqui — toque no menu do navegador e escolha "Abrir no navegador" antes de
+        entrar.
+      </Callout.Text>
+    </Callout.Root>
+  );
+};

--- a/client/src/features/auth/inAppBrowser.ts
+++ b/client/src/features/auth/inAppBrowser.ts
@@ -1,0 +1,36 @@
+// Deteccao de navegador embutido de app (Instagram, Facebook, TikTok...).
+//
+// Esses webviews tem cookie jar proprio: nao existe sessao do Spotify dentro
+// deles, entao o login sempre exige digitar email e senha, mesmo para quem esta
+// logado no Spotify no navegador de verdade. Alguns ainda quebram o redirect do
+// OAuth no meio do caminho.
+//
+// Nao da para consertar isso pelo app — o jeito e avisar e pedir para abrir no
+// navegador do sistema.
+
+const IN_APP_SIGNATURES = [
+  "FBAN", // Facebook (iOS)
+  "FBAV", // Facebook (Android)
+  "FB_IAB", // Facebook in-app browser
+  "Instagram",
+  "TikTok",
+  "BytedanceWebview",
+  "Line/",
+  "LinkedInApp",
+  "Snapchat",
+  "Pinterest",
+];
+
+/*
+ * Deteccao por user agent e imprecisa por natureza: identifica os webviews mais
+ * comuns, nao todos. Errar para menos e aceitavel — quem nao for detectado
+ * apenas nao ve o aviso, e o fluxo segue igual. Errar para mais custaria um
+ * aviso desnecessario, por isso a lista e de assinaturas explicitas e nao de
+ * heuristica generica de webview.
+ */
+export const isInAppBrowser = (): boolean => {
+  if (typeof navigator === "undefined") return false;
+
+  const userAgent = navigator.userAgent || "";
+  return IN_APP_SIGNATURES.some((signature) => userAgent.includes(signature));
+};

--- a/client/src/features/imageStudio/SocialShareRow.tsx
+++ b/client/src/features/imageStudio/SocialShareRow.tsx
@@ -5,14 +5,20 @@
 // - X, WhatsApp e Telegram tem endpoint de composicao por URL. Ele aceita texto
 //   e link, mas nao arquivo: abrimos a rede com a legenda pronta e baixamos a
 //   imagem para o usuario anexar.
-// - Instagram nao tem endpoint nenhum. O unico caminho que leva a imagem ate o
-//   story e a folha nativa (Web Share API), onde "Instagram > Stories" aparece
-//   como destino com o arquivo anexado — disponivel no celular. Fora dela, so da
-//   para baixar a imagem, copiar a legenda e avisar que a publicacao e no app.
+// - Instagram nao tem endpoint nenhum. O unico caminho que leva o arquivo a
+//   qualquer app e a folha nativa (Web Share API), disponivel no celular — mas
+//   quem escolhe o destino ali e o usuario, nao o site. Por isso o botao se
+//   chama "Compartilhar" e nao "Instagram Stories": prometer um destino
+//   especifico seria mentira, a folha pode nem listar o Instagram. Fora dela, so
+//   da para baixar a imagem, copiar a legenda e avisar que a publicacao e no app.
 
 import { useState } from "react";
 import { Button, Flex, Text } from "@radix-ui/themes";
-import { ExternalLinkIcon, InstagramLogoIcon } from "@radix-ui/react-icons";
+import {
+  ExternalLinkIcon,
+  InstagramLogoIcon,
+  Share2Icon,
+} from "@radix-ui/react-icons";
 import { APP_URL } from "../../shared/constants/app";
 import { canShareFiles } from "../../shared/image/useImageExport";
 import { INSTAGRAM_URL, socialTargets } from "./socialTargets";
@@ -74,8 +80,8 @@ export const SocialShareRow = ({
           disabled={disabled}
           onClick={shareToInstagram}
         >
-          <InstagramLogoIcon />
-          {nativeShare ? "Instagram Stories" : "Instagram"}
+          {nativeShare ? <Share2Icon /> : <InstagramLogoIcon />}
+          {nativeShare ? "Compartilhar" : "Instagram"}
         </Button>
 
         {socialTargets.map((target) => (
@@ -95,7 +101,7 @@ export const SocialShareRow = ({
 
       <Text as="p" size="1" color="gray">
         {nativeShare
-          ? "O Instagram abre a folha de compartilhamento do sistema — escolha Stories e a imagem vai anexada. Nas outras redes a legenda vai pronta e a imagem é baixada para você anexar."
+          ? "Compartilhar abre a folha do sistema com a imagem anexada — de lá você escolhe o app. Nas outras redes a legenda vai pronta e a imagem é baixada para você anexar."
           : "As redes não aceitam anexo por link: a imagem é baixada e a legenda vai preenchida — é só anexar o arquivo na hora de postar."}
       </Text>
 

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -6,6 +6,7 @@ import { EqualizerMark } from "../components/Layout/EqualizerMark";
 import { GitHubNavButton } from "../components/Layout/GitHubNavButton";
 import { Reveal } from "../components/Layout/Reveal";
 import { ThemeToggle } from "../components/Layout/ThemeToggle";
+import { InAppBrowserNotice } from "../features/auth/InAppBrowserNotice";
 import { LoginButton } from "../features/auth/LoginButton";
 import { isAuthenticated } from "../features/auth/auth";
 
@@ -74,12 +75,17 @@ export const Login = () => {
               </Text>
             </Reveal>
             <Reveal delay={0.24}>
-              <Flex mt="6" align="center" gap="4" wrap="wrap">
-                <LoginButton />
-                <Text size="1" color="gray" className="serif-accent">
-                  leva poucos segundos
-                </Text>
-              </Flex>
+              <Box mt="6">
+                {/* So aparece em navegador embutido de app, onde o login falha. */}
+                <InAppBrowserNotice />
+
+                <Flex align="center" gap="4" wrap="wrap">
+                  <LoginButton />
+                  <Text size="1" color="gray" className="serif-accent">
+                    leva poucos segundos
+                  </Text>
+                </Flex>
+              </Box>
             </Reveal>
             <Reveal delay={0.3}>
               <Text as="p" size="2" color="gray" mt="4">


### PR DESCRIPTION
Duas correcoes de borda no que os limites de plataforma impoem: o rotulo do
compartilhamento parou de prometer o que nao entrega, e a tela de login passa a
avisar quem abriu por dentro de outro app.

## Rotulo do compartilhamento

Com a Web Share API disponivel, o botao dizia **"Instagram Stories"** — mas o que
abre e a folha do sistema. Quem escolhe o destino ali e o usuario, e o Instagram
pode nem estar listado. Nao existe API web que mande um arquivo para um app
especifico.

Passa a se chamar **"Compartilhar"**, com icone de compartilhamento. Sem a Web
Share API, o botao continua "Instagram" e faz o que sempre fez: baixa a imagem,
copia a legenda e abre o site.

## Aviso de navegador embutido

Webview de app (Instagram, Facebook, TikTok, LinkedIn...) tem cookie jar
proprio: **nao existe sessao do Spotify dentro dele**. Quem entra por ali sempre
digita email e senha, mesmo estando logado no Spotify no navegador de verdade, e
alguns desses webviews quebram o redirect do OAuth no meio.

Isso nao tem conserto pelo app — o fluxo OAuth exige o navegador. O que da para
fazer e avisar, entao a tela de login mostra um `Callout` pedindo para abrir no
navegador do sistema.

A deteccao e por assinatura explicita de user agent, nao heuristica generica de
webview: errar para menos so significa nao mostrar o aviso, e o fluxo segue
igual; errar para mais mostraria aviso a quem nao precisa.

## Verificacao

- `npm run build` passa.
- Deteccao testada em sete user agents: Instagram, Facebook, TikTok e LinkedIn
  avisam; Safari, Chrome Android e Firefox desktop nao.

## Nao verificado

Nada foi visto renderizado. Em especial, o `Callout` na tela de login so aparece
em webview embutido, entao so da para conferir abrindo o link de dentro do
Instagram ou do Facebook.

## Fica para depois

O compartilhamento com preview de imagem real no X/WhatsApp/Telegram exige
hospedar a imagem e servir uma pagina com `og:image`. Esta planejado em
`docs/tasks/14-compartilhamento-hospedado.md` (documentacao local, fora do
repositorio) — tem implicacao de privacidade, porque transforma stats pessoais
em URL publica.
