### PR TITLE
ci: roda build e a suite de testes no GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+# CI: build e a suite de testes inteira.
+#
+# Um job so, sequencial, porque a suite leva ~87s medidos. Cada job extra
+# custaria boot de runner e um `npm ci` proprio nas duas arvores — mais caro que
+# o paralelismo economizaria. Dividir passa a valer se isto ultrapassar uns 5
+# minutos.
+#
+# Nao publica nada: o deploy e da Netlify, a partir do `main`. No plano free por
+# creditos cada deploy de producao custa 15 de 300 mensais, entao um workflow que
+# dispare deploy extra consome a cota do mes em silencio.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Push novo no mesmo PR cancela a execucao anterior: evita fila e minuto gasto
+# em commit ja superado.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-e-testes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # A versao sai do .nvmrc para nao virar mais uma copia que envelhece
+      # sozinha — o netlify.toml ja repete a mesma.
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
+
+      # As duas arvores: `@playwright/test` esta na raiz e o resto do
+      # ferramental de teste em `client/`. Instalar so um lado quebra o E2E com
+      # "playwright: not found".
+      - name: Instalar dependencias
+        run: |
+          npm ci
+          npm ci --prefix client
+
+      - name: Build
+        run: npm run build
+
+      # Inclui os limiares de cobertura configurados no vitest.
+      - name: Testes e cobertura
+        run: npm run test:coverage
+
+      - name: Instalar o Chromium
+        run: npx playwright install --with-deps chromium
+
+      # Roda contra o build de producao via `vite preview`: e la que a base da
+      # API e o `/api` same-origin, que e o caso que ja quebrou.
+      - name: Testes E2E
+        run: npm run test:e2e
+
+      # `break threshold: 90`, score atual 94,95%. Se ficar instavel no runner,
+      # a correcao e um `if: github.event_name == 'push'` aqui.
+      - name: Mutation testing
+        run: npm run test:mutation

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -27,7 +27,7 @@
         "@vitejs/plugin-react-swc": "^3.0.0",
         "@vitest/coverage-v8": "^4.1.10",
         "autoprefixer": "^10.4.13",
-        "jsdom": "^30.0.1",
+        "jsdom": "^29.1.1",
         "postcss": "^8.4.21",
         "tailwindcss": "^3.2.4",
         "typescript": "5.6.3",
@@ -36,37 +36,55 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
-      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.3.0",
-        "@csstools/css-color-parser": "^4.1.10",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.5.2"
+        "@csstools/css-tokenizer": "^4.0.0"
       },
       "engines": {
-        "node": "^22.13.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
-      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2"
+        "is-potential-custom-element-name": "^1.0.1"
       },
       "engines": {
-        "node": "^22.13.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -4658,21 +4676,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5550,39 +5553,39 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/jsdom": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
-      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^6.0.5",
-        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
-        "@exodus/bytes": "^1.15.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2",
+        "lru-cache": "^11.3.5",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.2",
-        "undici": "^8.9.0",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^17.1.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "canvas": "^3.2.3"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -7456,13 +7459,13 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unicorn-magic": {
@@ -8323,18 +8326,18 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
-      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.15.1",
+        "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
         "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": "^22.14.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -8443,29 +8446,42 @@
   },
   "dependencies": {
     "@asamuzakjp/css-color": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
-      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "requires": {
-        "@csstools/css-calc": "^3.3.0",
-        "@csstools/css-color-parser": "^4.1.10",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.5.2"
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "@asamuzakjp/dom-selector": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
-      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "requires": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2"
+        "is-potential-custom-element-name": "^1.0.1"
       }
+    },
+    "@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true
+    },
+    "@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.29.7",
@@ -10983,19 +10999,6 @@
       "requires": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
-      },
-      "dependencies": {
-        "whatwg-url": {
-          "version": "16.0.1",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-          "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-          "dev": true,
-          "requires": {
-            "@exodus/bytes": "^1.11.0",
-            "tr46": "^6.0.0",
-            "webidl-conversions": "^8.0.1"
-          }
-        }
       }
     },
     "debug": {
@@ -11604,31 +11607,31 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "jsdom": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
-      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "requires": {
-        "@asamuzakjp/css-color": "^6.0.5",
-        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
-        "@exodus/bytes": "^1.15.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2",
+        "lru-cache": "^11.3.5",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.2",
-        "undici": "^8.9.0",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^17.1.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       }
     },
@@ -12755,9 +12758,9 @@
       "dev": true
     },
     "undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true
     },
     "unicorn-magic": {
@@ -13130,12 +13133,12 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
-      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "requires": {
-        "@exodus/bytes": "^1.15.1",
+        "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
         "webidl-conversions": "^8.0.1"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,7 @@
     "@vitejs/plugin-react-swc": "^3.0.0",
     "@vitest/coverage-v8": "^4.1.10",
     "autoprefixer": "^10.4.13",
-    "jsdom": "^30.0.1",
+    "jsdom": "^29.1.1",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.2.4",
     "typescript": "5.6.3",


### PR DESCRIPTION
Roda build, testes, E2E e mutation testing no GitHub Actions, em PR e em push
para `main`.

## As medicoes que desenharam o pipeline

Cada comando foi executado nesta maquina antes de entrar no YAML:

| Etapa | Tempo |
| --- | --- |
| `npm run build` | 6,6s |
| `npm run test:coverage` (244 testes) | 4,6s |
| `npm run test:e2e` (23 specs) | 11,5s |
| `npm run test:mutation` (score 94,95%) | 64,0s |
| **Total** | **~87s** |

Esse numero decide quase tudo o resto.

## Um job so

Cada job adicional custa boot de runner (~10-20s) **e** um `npm ci` proprio nas
duas arvores (~30-40s). Dividir em quatro jobs paralelos economizaria talvez 60s
de relogio e gastaria mais de 120s de runner, alem de quadruplicar a
configuracao.

Um workflow, um job, passos sequenciais. Isso deixa de valer se a suite passar de
uns 5 minutos — o sinal para dividir e o tempo, nao a estetica.

## Uma pegadinha que encontrei medindo

**`@playwright/test` esta declarado na raiz**, e o resto do ferramental de teste
em `client/`. Instalar so um lado quebra com `playwright: not found` — aconteceu
comigo ao medir. Por isso o passo de install roda `npm ci` **nas duas arvores**.

## Sem matriz

O app roda numa versao so de Node: `20.19.0`, no `.nvmrc` e repetida no
`netlify.toml`. Testar em 18/20/22 testaria combinacao que a producao nunca vai
encontrar. O workflow le a versao do proprio `.nvmrc`, entao ela nao vira uma
terceira copia que envelhece sozinha.

## Sem upload de artefato

O `playwright.config.ts` usa `reporter: process.env.CI ? "list" : [...html...]` —
**no CI o relatorio HTML nao e gerado**. Um passo de upload subiria pasta
inexistente. O reporter `list` ja imprime a falha no log, que e onde se olha
primeiro.

## CI, nunca CD

O deploy continua sendo da Netlify, a partir do `main`. O Actions nao publica
nada — e isso importa alem da divisao de responsabilidade: no plano free por
creditos, **cada deploy de producao custa 15 de 300 mensais**. Um workflow que
dispare deploy extra consome a cota do mes em silencio.

## O que bloqueia

Sendo um job so, tudo bloqueia: install, build (que inclui `tsc`), cobertura com
os limiares configurados, E2E e mutation (`break threshold: 90`, score atual
94,95%).

Nao ha passo consultivo de proposito. Um job que as vezes fica vermelho e
ignorado deixa de proteger.

## Duas linhas de higiene

`concurrency` com `cancel-in-progress` (push novo cancela execucao superada) e
`permissions: contents: read` (o padrao do Actions e mais permissivo).

## Pendencias

- **Proteger o `main` exigindo este check.** O workflow reporta, mas sozinho nao
  impede merge — isso e configuracao do GitHub, nao do repositorio.
- Se o mutation testing ficar instavel no runner compartilhado, a correcao e um
  `if: github.event_name == 'push'` no passo. Nao antecipei por nao ter
  evidencia de flakiness.
- Cache dos browsers do Playwright (~40s), se incomodar. Nao entrou porque a
  chave precisa acompanhar a versao do Playwright e sai de sincronia em silencio.
